### PR TITLE
Removed PHP 5.4 array literal

### DIFF
--- a/src/Auryn/Provider.php
+++ b/src/Auryn/Provider.php
@@ -242,7 +242,7 @@ class Provider implements Injector {
      * @param mixed $callableOrMethodArr Valid PHP callable or an array of the form [$className, $methodName]
      * @param array $invocationArgs Optional array specifying params to invoke the provisioned callable
      */
-    function execute($callableOrMethodArr, array $invocationArgs = []) {
+    function execute($callableOrMethodArr, array $invocationArgs = array()) {
         list($callableRefl, $invocationObj) = $this->generateCallableReflection($callableOrMethodArr);
         $args = $this->generateInvocationArgs($callableRefl, $invocationArgs);
         


### PR DESCRIPTION
The library home page states that it is 5.3 compatible, so I've swapped a 5.4 array literal for 5.3-style syntax to make it 5.3 compatible again.
