### PR TITLE
Provider Builder for file-based configuration [incomplete]

### DIFF
--- a/src/Auryn/ProviderBuilder.php
+++ b/src/Auryn/ProviderBuilder.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Auryn;
+
+class ProviderBuilder {
+
+    public function fromArray(Provider $provider, array $configuration) {
+        $this->validateConfiguration($configuration);
+
+        foreach ($configuration as $configurationType => $configurationValues) {
+            switch ($configurationType) {
+                case 'aliases':
+                    $this->addAliases($provider, $configurationValues);
+                    break;
+                case 'definitions':
+                    $this->addDefinitions($provider, $configurationValues);
+                    break;
+                case 'shares':
+                    $this->addShares($provider, $configurationValues);
+                    break;
+                case 'delegates':
+                    $this->addDelegates($provider, $configurationValues);
+                    break;
+                default:
+                    throw new \InvalidArgumentException("Invalid configuration key: {$configurationType} - did you forget to add a new configuration type handler to fromArray()?");
+                    break;
+            }
+        }
+    }
+
+    /**
+     * @param array $configuration
+     * @throws \InvalidArgumentException
+     */
+    private function validateConfiguration(array $configuration)
+    {
+        foreach (array_keys($configuration) as $key) {
+            if ( ! in_array($key, array(
+                'aliases',
+                'definitions',
+                'shares',
+                'delegates'
+            ))) {
+                throw new \InvalidArgumentException("Invalid configuration key: {$key}");
+            }
+        }
+    }
+
+    /**
+     * @param Provider $provider
+     * @param $configurationValues
+     */
+    private function addAliases(Provider $provider, $configurationValues)
+    {
+        foreach ($configurationValues as $typeHintToReplace => $alias) {
+            $provider->alias($typeHintToReplace, $alias);
+        }
+    }
+
+    /**
+     * @param Provider $provider
+     * @param $configurationValues
+     */
+    private function addDefinitions(Provider $provider, $configurationValues)
+    {
+        foreach ($configurationValues as $className => $definition) {
+            $provider->define($className, $definition);
+        }
+    }
+
+    /**
+     * @param Provider $provider
+     * @param $configurationValues
+     */
+    private function addShares(Provider $provider, $configurationValues)
+    {
+        foreach ($configurationValues as $share) {
+            $provider->share($share);
+        }
+    }
+
+    /**
+     * @param Provider $provider
+     * @param $configurationValues
+     */
+    private function addDelegates(Provider $provider, $configurationValues)
+    {
+        foreach ($configurationValues as $className => $delegate) {
+            $provider->delegate($className, $delegate);
+        }
+    }
+
+}

--- a/test/src/Auryn/ProviderBuilderTest.php
+++ b/test/src/Auryn/ProviderBuilderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use \Auryn\ProviderBuilder;
+
+class ProviderBuilderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Auryn\ProviderBuilder
+     */
+    private $builder;
+
+    protected function setUp()
+    {
+        $this->builder = new ProviderBuilder;
+    }
+
+    /**
+     * @covers \Auryn\ProviderBuilder::fromArray
+     * @expectedException InvalidArgumentException
+     */
+    public function testFromArrayThrowsExceptionIfInvalidKeyFound() {
+        $this->builder->fromArray($this->getMock('\Auryn\Provider'), array('InvalidKey' => 'value'));
+    }
+
+    /**
+     * @covers \Auryn\ProviderBuilder::fromArray
+     */
+    public function testFromArrayWithAliasSpecifiedCallsAliasMethodOnProvider() {
+        $provider = $this->getMock('\Auryn\Provider', array('alias'));
+        $provider->expects($this->once())
+            ->method('alias')
+            ->with(
+                $this->equalTo('SomeInterface'),
+                $this->equalTo('SomeImplementationClass')
+            );
+
+        $this->builder->fromArray($provider, array(
+            'aliases' => array(
+                'SomeInterface' => 'SomeImplementationClass'
+            )
+        ));
+    }
+
+    /**
+     * @covers \Auryn\ProviderBuilder::fromArray
+     */
+    public function testFromArrayWithDefinitionSpecifiedCallsDefineMethodOnProvider() {
+        $provider = $this->getMock('\Auryn\Provider', array('define'));
+        $provider->expects($this->once())
+            ->method('define')
+            ->with(
+                $this->equalTo('SomeImplementationClass'),
+                $this->equalTo(array(':arg1' => 'SomeString'))
+            );
+
+        $this->builder->fromArray($provider, array(
+            'definitions' => array(
+                'SomeImplementationClass' => array(
+                    ':arg1' => 'SomeString'
+                )
+            )
+        ));
+    }
+
+    /**
+     * @covers \Auryn\ProviderBuilder::fromArray
+     */
+    public function testFromArrayWithSharedDependencySpecifiedCallsShareMethodOnProvider() {
+        $provider = $this->getMock('\Auryn\Provider', array('share'));
+        $provider->expects($this->once())
+            ->method('share')
+            ->with($this->equalTo('MyUniversalClass'));
+
+        $this->builder->fromArray($provider, array(
+            'shares' => array('MyUniversalClass')
+        ));
+    }
+
+    /**
+     * @covers \Auryn\ProviderBuilder::fromArray
+     */
+    public function testFromArrayWithDelegateSpecifiedCallsDelegateMethodOnProvider() {
+        $provider = $this->getMock('\Auryn\Provider', array('delegate'));
+        $provider->expects($this->once())
+            ->method('delegate')
+            ->with(
+                $this->equalTo('SomeImplementationClass'),
+                $this->equalTo('SomeCallable')
+            );
+
+        $this->builder->fromArray($provider, array(
+            'delegates' => array(
+                'SomeImplementationClass' => 'SomeCallable'
+            )
+        ));
+    }
+}


### PR DESCRIPTION
Hi - I've got the coding itch today :)

Attached is an attempt at a simple method to take a PHP array in the format you mentioned in issue #4 and apply that configuration to an existing Provider using the appropriate methods on the given Provider object.

The idea being that there would be other classes that use this to generate a Provider for you.

A YAML parser then, for example, would be a simple class that takes a filename, parses the YAML file into a PHP array, then uses this class to build the Provider.

Not sure if this is what you were thinking of, but as I said, I had the itch to do some programming!
