### PR TITLE
Fixed namespace regression + 5.3 compatibility in tests

### DIFF
--- a/src/Auryn/Provider.php
+++ b/src/Auryn/Provider.php
@@ -44,7 +44,7 @@ class Provider implements Injector {
             $delegate = $this->delegatedClasses[$lowClass];
             $provisionedObject = $this->doDelegation($delegate, $className);
         } else {
-            $injectionDefinition = $this->selectDefinition($lowClass, $customDefinition);
+            $injectionDefinition = $this->selectDefinition($className, $customDefinition);
             $provisionedObject = $this->getInjectedInstance($className, $injectionDefinition);
         }
         

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -4,3 +4,4 @@ define('FIXTURE_DIR', __DIR__ . '/fixture');
 
 require dirname(__DIR__) . '/autoload.php';
 require __DIR__ . '/fixture/ProviderTestClasses.php';
+require __DIR__ . '/fixture/NamespacedClass.php';

--- a/test/fixture/NamespacedClass.php
+++ b/test/fixture/NamespacedClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace SomeNamespace;
+
+class SomeClassName {}

--- a/test/src/Auryn/ProviderTest.php
+++ b/test/src/Auryn/ProviderTest.php
@@ -318,6 +318,14 @@ class ProviderTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @covers Auryn\Provider::make
+     */
+    public function testMakeHandlesNamespacedClasses() {
+        $provider = new Provider(new ReflectionPool);
+        $provider->make('SomeNamespace\\SomeClassName');
+    }
+
+    /**
      * @covers Auryn\Provider::delegate
      * @covers Auryn\Provider::doDelegation
      * @covers Auryn\Provider::make
@@ -521,7 +529,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase {
     
     public function testDelegateInstantiatesCallableClassArray() {
         $provider = new Provider;
-        $provider->delegate('MadeByDelegate', ['CallableDelegateClassTest', '__invoke']);
+        $provider->delegate('MadeByDelegate', array('CallableDelegateClassTest', '__invoke'));
         $this->assertInstanceof('MadeByDelegate', $provider->make('MadeByDelegate'));
     }
     


### PR DESCRIPTION
It looks like I broke namespaced classes with my previous PR (definition inheritance) - this patch should fix that issue. I've also removed an instance of 5.4 array-literal syntax in the tests - I have no real issue with the tests being 5.4+ only but it makes sense to have them 5.3 compatible if the library is.
