### PR TITLE
Delegate interface implementation creation to factory.

### DIFF
--- a/src/Auryn/Provider.php
+++ b/src/Auryn/Provider.php
@@ -56,7 +56,7 @@ class Provider implements Injector {
     }
     
     private function delegateExists($class) {
-        return array_key_exists($class, $this->delegatedClasses);
+        return array_key_exists(strtolower($class), $this->delegatedClasses);
     }
     
     private function doDelegation($callable, $class) {
@@ -418,7 +418,7 @@ class Provider implements Injector {
     private function buildArgumentFromTypeHint(\ReflectionMethod $reflMethod, \ReflectionParameter $reflParam) {
         $typeHint = $this->reflectionStorage->getParamTypeHint($reflMethod, $reflParam);
           
-        if ($typeHint && $this->isInstantiable($typeHint)) {
+        if ($typeHint && ($this->isInstantiable($typeHint) || $this->delegateExists($typeHint))) {
             return $this->make($typeHint);
         } elseif ($typeHint) {
             return $this->buildAbstractTypehintParam($typeHint, $reflParam->name);

--- a/test/fixture/ProviderTestClasses.php
+++ b/test/fixture/ProviderTestClasses.php
@@ -188,3 +188,28 @@ class CallableDelegateClassTest {
     }
 }
 
+interface DelegatableInterface {
+    function foo();
+}
+
+class ImplementsInterface implements DelegatableInterface{
+    function foo(){
+    }
+}
+
+class ImplementsInterfaceFactory{
+    public function __invoke() {
+        return new ImplementsInterface();
+    }
+}
+
+class RequiresDelegatedInterface {
+    private $interface;
+
+    public function __construct(DelegatableInterface $interface) {
+        $this->interface = $interface;
+    }
+    public function foo() {
+        $this->interface->foo();
+    }
+}

--- a/test/src/Auryn/ProviderTest.php
+++ b/test/src/Auryn/ProviderTest.php
@@ -645,6 +645,12 @@ class ProviderTest extends PHPUnit_Framework_TestCase {
         
         return $return;
     }
-    
+
+    public function testInterfaceFactoryDelegation() {
+        $injector = new Auryn\Provider(new Auryn\ReflectionPool);
+        $injector->delegate('DelegatableInterface', 'ImplementsInterfaceFactory');
+        $requiresDelegatedInterface = $injector->make('RequiresDelegatedInterface');
+        $requiresDelegatedInterface->foo();
+    }
 }
 


### PR DESCRIPTION
Added ability to delegate creation of interface implementations to factories.

e.g. so that in:
class TestClass{
    function __construct(LoggerInterface $logger){}
}

the $logger can be created via a LoggerFactory if it has been delegated as:
$provider->delegate('LoggerInterface', 'LoggerFactory');
