### PR TITLE
Allow delegates to be called with parameters.

### DIFF
--- a/src/Auryn/Injector.php
+++ b/src/Auryn/Injector.php
@@ -36,8 +36,10 @@ interface Injector {
      *
      * @param string $className
      * @param callable $callable
+     * @param array $args
+     * @return
      */
-    function delegate($className, $callable);
+    function delegate($className, $callable, array $args = []);
     
     /**
      * Shares the specified class across the Injector context

--- a/src/Auryn/Provider.php
+++ b/src/Auryn/Provider.php
@@ -66,9 +66,9 @@ class Provider implements Injector {
         return isset($this->delegatedClasses[strtolower($class)]);
     }
     
-    private function doDelegation($callable, $class) {
+    private function doDelegation(array $callable, $class) {
         try {
-            $provisionedObject = $this->execute($callable);
+            $provisionedObject = $this->execute($callable[0], $callable[1]);
         } catch (\Exception $e) {
             throw new InjectionException(
                 "Delegation failed while attempting to provision {$class}",
@@ -255,12 +255,12 @@ class Provider implements Injector {
      * @throws \Auryn\BadArgumentException
      * @return \Auryn\Provider Returns the current instance
      */
-    function delegate($className, $callable) {
+    function delegate($className, $callable, array $args = []) {
         if (is_callable($callable)
             || (is_string($callable) && method_exists($callable, '__invoke'))
             || (is_array($callable) && isset($callable[0], $callable[1]) && method_exists($callable[0], $callable[1]))
         ) {
-            $delegate = $callable;
+            $delegate = [$callable, $args];
         } else {
             throw new BadArgumentException(
                 get_class($this) . '::delegate expects a valid callable or provisionable executable ' .
@@ -369,7 +369,7 @@ class Provider implements Injector {
         
         foreach ($funcReflParamsArr as $funcParam) {
             $rawParamKey = self::RAW_INJECTION_PREFIX . $funcParam->name;
-            
+
             if (isset($definition[$funcParam->name])) {
                 $funcArgs[] = $this->make($definition[$funcParam->name]);
             } elseif (isset($definition[$rawParamKey])) {

--- a/test/fixture/ProviderTestClasses.php
+++ b/test/fixture/ProviderTestClasses.php
@@ -150,6 +150,12 @@ class CallableMock {
     }
 }
 
+class CallableMockWithArgs {
+    function __invoke($arg1, $arg2) {
+
+    }
+}
+
 class StringStdClassDelegateMock {
     function __invoke() {
         return $this->make();

--- a/test/src/Auryn/ProviderTest.php
+++ b/test/src/Auryn/ProviderTest.php
@@ -334,6 +334,30 @@ class ProviderTest extends PHPUnit_Framework_TestCase {
 
         $this->assertInstanceOf('TestDependency', $obj);
     }
+
+    /**
+     * @covers Auryn\Provider::delegate
+     * @covers Auryn\Provider::doDelegation
+     * @covers Auryn\Provider::make
+     */
+    public function testMakeDelegateWithArgs() {
+        $provider= new Provider(new ReflectionPool);
+
+        $callable = $this->getMock(
+            'CallableMockWithArgs',
+            array('__invoke')
+        );
+        $callable->expects($this->once())
+            ->method('__invoke')
+            ->with(1, 2)
+            ->will($this->returnValue(new TestDependency()));
+
+        $provider->delegate('TestDependency', $callable, [':arg1' => 1, ':arg2' => 2]);
+
+        $obj = $provider->make('TestDependency');
+
+        $this->assertInstanceOf('TestDependency', $obj);
+    }
     
     /**
      * @covers Auryn\Provider::doDelegation


### PR DESCRIPTION
Not sure if useful. This was kind of a knee-jerk modification, and there may be a better way of doing it already (like supplying a closure for the factory method), so feel free to reject this pull if you feel this doesn't fit.

I made the changes because I often see factories used like:

```
$db = DatabaseFactory::getAdapter('MySQL', $options);
```

The change would allow delegates to be used like:

```
$injector->delegate('Database', 'DatabaseFactory', [':adapter' => 'MySQL', 'options' => $options]);
$injector->make('Database');
```
