### PR TITLE
Corrected calling of ->execute() on a function which requires parameters.

### DIFF
--- a/src/Auryn/Executable.php
+++ b/src/Auryn/Executable.php
@@ -44,7 +44,7 @@ class Executable {
 
         return $this->isMethod
             ? $this->callableReflection->invokeArgs($this->methodInvocationObject, $args)
-            : $this->callableReflection->invoke($args);
+            : $this->callableReflection->invokeArgs($args);
     }
 
 }

--- a/test/fixture/ProviderTestClasses.php
+++ b/test/fixture/ProviderTestClasses.php
@@ -282,6 +282,10 @@ function testExecuteFunction() {
     return 42;
 }
 
+function testExecuteFunctionWithArg(ConcreteClass1 $foo) {
+    return 42;
+}
+
 class MadeByDelegate {}
 
 class CallableDelegateClassTest {

--- a/test/src/Auryn/ProviderTest.php
+++ b/test/src/Auryn/ProviderTest.php
@@ -531,6 +531,12 @@ class ProviderTest extends PHPUnit_Framework_TestCase {
         $expectedResult = 42;
         $return[] = array($toInvoke, $args, $expectedResult);
 
+
+        $toInvoke = 'testExecuteFunctionWithArg';
+        $args = array();
+        $expectedResult = 42;
+        $return[] = array($toInvoke, $args, $expectedResult);
+        
         // x -------------------------------------------------------------------------------------->
 
         return $return;


### PR DESCRIPTION
The wrong invoke method for ReflectionFunction is used which lead to:

> Argument 1 passed to testExecuteFunctionWithArg() must be an instance of ConcreteClass1, array given

Changed to the correct method.
