### PR TITLE
Added test case that fails.

### DIFF
--- a/test/fixture/ProviderTestClasses.php
+++ b/test/fixture/ProviderTestClasses.php
@@ -56,6 +56,10 @@ class SharedClass implements SharedAliasedInterface {
     function foo(){}
 }
 
+class NotSharedClass implements SharedAliasedInterface {
+    function foo(){}
+}
+
 class ClassWithAliasAsParameter {
 
     private $sharedClass;

--- a/test/unit/Auryn/ProviderTest.php
+++ b/test/unit/Auryn/ProviderTest.php
@@ -574,6 +574,17 @@ class ProviderTest extends PHPUnit_Framework_TestCase {
         $this->assertSame($class, $class2);
     }
 
+    public function testNotSharedByAliasedInterfaceName() {
+        $provider = new Auryn\Provider();
+        $provider->alias('SharedAliasedInterface', 'SharedClass');
+        $provider->alias('SharedAliasedInterface', 'NotSharedClass');
+        $provider->share('SharedClass');
+        $class = $provider->make('SharedAliasedInterface');
+        $class2 = $provider->make('SharedAliasedInterface');
+
+        $this->assertNotEquals($class, $class2);
+    }
+
     public function testSharedByAliasedInterfaceNameReversedOrder() {
         $provider = new Auryn\Provider();
         $provider->share('SharedAliasedInterface');


### PR DESCRIPTION
This looks like a bug to me - can you let me know if you think this is a bug?

I've almost finished my fork for storing provider info via plugins, but have had some difficultly with aliasing + sharing. I was trying to figure out what was meant to be happening and found what looks like a bug.

The cause is that the code is trying to be clever, by pre-calculating some stuff before an object is instantiated [here](https://github.com/rdlowrey/Auryn/blob/master/lib/Auryn/Provider.php#L303-L305) and [here](https://github.com/rdlowrey/Auryn/blob/master/lib/Auryn/Provider.php#L273-L276)

If you can just confirm that this is a bug, I'll fix it in a day or two once real life stops getting in the way.
