### PR TITLE
Update composer.json to use correct directory for PSR-0 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "autoload": {
     "psr-0": {
-      "Auryn": "src"
+      "Auryn": "lib"
     }
   }
 }


### PR DESCRIPTION
When Composer generates the autoloading files, it picks up on the `autoload.psr-0` key from `composer.json`. The `Auryn` namespace is mapped to the `src/` directory which does not exist.

This commit changes the directory to `lib` so the correct autoloading files can be generated.

I am missing something... this used to work until a recent `composer update`?

**EDIT**: GitHub edit sneaked a new line at the end of the file, should be OK.
