### PR TITLE
Make buildArgumentFromTypeHint use shared classes

### DIFF
--- a/lib/Auryn/Provider.php
+++ b/lib/Auryn/Provider.php
@@ -602,6 +602,8 @@ class Provider implements Injector {
 
         if (!$typeHint) {
             $object = NULL;
+        } elseif (isset($this->sharedClasses[$typeHintLower])) {
+            $object = $this->sharedClasses[$typeHintLower];
         } elseif ($this->isInstantiable($typeHint)
             || isset($this->aliases[$typeHintLower])
             || isset($this->delegatedClasses[$typeHintLower])


### PR DESCRIPTION
If you shared a class for some reason and you try to make a new class with a dependency to that shared class it wouldn't use the shared one, this change request fixes that.
