### PR TITLE
Fix README.md PDO example s/:password/:passwd/

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ $injector->share('PDO');
 $injector->define('PDO', array(
     ':dsn' => 'mysql:dbname=testdb;host=127.0.0.1',
     ':username' => 'dbuser',
-    ':password' => 'dbpass'
+    ':passwd' => 'dbpass'
 ));
 
 $db = $injector->make('PDO');


### PR DESCRIPTION
I used the example in README.md for PDO and got an issue because it could not connect (NO PASSWORD). After looking around I've found the parameter name is "passwd" (even is php.net doc is using $password).

Tested it here https://github.com/4d47/php-learning-experience/blob/master/tests/Class/ReflectionClassTest.php
Probably because of something around here: https://github.com/php/php-src/blob/master/ext/pdo/pdo_dbh.c#L1220
