### PR TITLE
Updated Provider to fix issue with namespace defines

### DIFF
--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -178,7 +178,7 @@ class Provider implements Injector {
     }
 
     private function getDefinition($className) {
-        $lowClass = strtolower($className);
+        $lowClass = ltrim(strtolower($className),'\\');
 
         return $this->isDefined($lowClass)
             ? $this->injectionDefinitions[$lowClass]
@@ -186,7 +186,7 @@ class Provider implements Injector {
     }
 
     private function isDefined($className) {
-        $lowClass = strtolower($className);
+        $lowClass = ltrim(strtolower($className),'\\');
 
         return isset($this->injectionDefinitions[$lowClass]);
     }


### PR DESCRIPTION
Provider:define trims backslashes from the start of the class name, where as Provider::isDefined and Provider::getDefinition do not, These have been updated to mirror the behaviour.
