### PR TITLE
Use PSR-4 autoloading for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
     "php": ">=5.3.0"
   },
   "autoload": {
-    "files": ["src/bootstrap.php"]
+    "psr-4": {
+      "Auryn\\": "lib/"
+    }
   }
 }


### PR DESCRIPTION
[PSR-4](https://github.com/php-fig/fig-standards/blob/master/proposed/psr-4-autoloader/psr-4-autoloader.md) makes it possible to use the Composer autoloader without reflecting the entire namespace in the folder structure. I've tested this with a sample project and it works fine.
