### PR TITLE
Prepare objects with extended class preparers

### DIFF
--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -388,6 +388,16 @@ class Provider implements Injector {
                 $exe($obj, $this);
             }
         }
+
+        $parentClass = get_parent_class($obj);
+        if ($parentClass) {
+            $parentClass = $this->normalizeClassName($parentClass);
+            if (isset($this->prepares[$parentClass])) {
+                $preparer = $this->prepares[$parentClass];
+                $exe = $this->getExecutable($preparer);
+                $exe($obj, $this);
+            }
+        }
     }
 
 

--- a/test/ProviderTest.php
+++ b/test/ProviderTest.php
@@ -919,4 +919,15 @@ class ProviderTest extends PHPUnit_Framework_TestCase {
 
         $this->assertSame(42, $obj->testProp);
     }
+
+    public function testAbstractClassPrepare() {
+        $provider = new Provider();
+        $provider->prepare('AbstractPrepareClass', function($obj, Provider $injector) {
+            $obj->setParam('some param');
+        });
+
+        $obj = $provider->make('ConcretePrepareClass');
+
+        $this->assertSame('some param', $obj->getParam());
+    }
 }

--- a/test/fixture/ProviderTestClasses.php
+++ b/test/fixture/ProviderTestClasses.php
@@ -402,3 +402,19 @@ class SimpleNoTypehintClass {
     }
 
 }
+
+abstract class AbstractPrepareClass {
+
+    private $param;
+
+    public function setParam($param) {
+        $this->param = $param;
+    }
+
+    public function getParam() {
+        return $this->param;
+    }
+
+}
+
+class ConcretePrepareClass extends AbstractPrepareClass {}


### PR DESCRIPTION
Adds appropriate test and code to run preparers for the parent class of an object. This allows a dependency setter to be declared on the parent class and will be invoked for all children classes extending from it.

Here's an example use case:

``` php
abstract class AppController {

    private $doohickey;

    function setDoohickey(Doohickey $doohickey) {
        $this->doohickey = $doohickey;
    }

    function getDoohickey() {
        $this->doohickey;
    }

}

class FooController extends AppController {}
class BarController extends AppController {}

$provider->prepare('AppController', function($controller, $injector) {
    $controller->setDoohickey($injector->make('Doohickey'));
});

$foo = $provider->make('FooController'); // $foo->setDoohickey() is called
```
