### PR TITLE
$this isn't used when invoking a ReflectionFunction with Closures

### DIFF
--- a/lib/Executable.php
+++ b/lib/Executable.php
@@ -40,9 +40,14 @@ class Executable {
 
     public function __invoke() {
         $args = func_get_args();
+        $reflection = $this->callableReflection;
 
-        return $this->isMethod
-            ? $this->callableReflection->invokeArgs($this->invocationObject, $args)
-            : $this->callableReflection->invokeArgs($args);
+        if ($this->isMethod) {
+            return $reflection->invokeArgs($this->methodInvocationObject, $args);
+        }
+
+        return $this->callableReflection->isClosure()
+            ? call_user_func_array(\Closure::bind($reflection->getClosure(), $reflection->getClosureThis(), $reflection->getClosureScopeClass()->name), $args)
+            : $reflection->invokeArgs($args);
     }
 }


### PR DESCRIPTION
```
Bobs-MacBook-Pro-2:php-src-5.6 bob$ php -r 'class a { private $success = "success\n"; function b() { return new ReflectionFunction(function() { print $this->success; }); } } $a = (new a)->b(); $c = $a->invoke();'

Fatal error: Using $this when not in object context in Command line code on line 1
```

Exactly this issue we are experiencing here — the Closure was passed to ReflectionFunction and `$this` Information will get lost upon `ReflectionFunction::invoke(Args)()`. So, we need to manually rebind the Closure and call it. (well, yeah, `ReflecttionFunction::getClosure()` also isn't bound...)
