### PR TITLE
Append/override injection definitions to existing ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auryn Injector
 
-Auryn is a flexible recursive dependency injector. Use Auryn to bootstrap and wire together
+Auryn is a recursive dependency injector. Use Auryn to bootstrap and wire together
 S.O.L.I.D., object-oriented PHP applications.
 
 ##### How It Works

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -23,6 +23,14 @@ interface Injector {
     public function define($className, array $injectionDefinition);
 
     /**
+     * Appends a custom injection definition to the specified class injection definitions
+     *
+     * @param string $className The class whose instantiation we wish to add defines to
+     * @param array $injectionDefinition An array mapping parameter names to classes and/or raw values
+     */
+    public function appendDefine($className, array $injectionDefinition);
+
+    /**
      * Assign a global default value for all parameters named $paramName
      *
      * Global parameter definitions are only used for parameters with no typehint, pre-defined or

--- a/lib/Provider.php
+++ b/lib/Provider.php
@@ -103,6 +103,23 @@ class Provider implements Injector {
 
 
     /**
+     * Appends a custom injection definition to the specified class injection definitions
+     *
+     * @param string $className
+     * @param array $injectionDefinition An associative array matching constructor params to values
+     * @throws \Auryn\BadArgumentException On missing raw injection prefix
+     * @return \Auryn\Provider Returns the current instance
+     */
+    public function appendDefine($className, array $injectionDefinition) {
+        $this->validateInjectionDefinition($injectionDefinition);
+        $normalizedClass = $this->normalizeClassName($className);
+        $this->injectionDefinitions[$normalizedClass] = array_merge($this->injectionDefinitions[$normalizedClass], $injectionDefinition);
+
+        return $this;
+    }
+
+
+    /**
      * Assign a global default value for all parameters named $paramName
      *
      * Global parameter definitions are only used for parameters with no typehint, pre-defined or


### PR DESCRIPTION
Useful if you need to append or override injection definitions.

Append example

	$response = $injector->make('Symfony\Component\HttpFoundation\Response');

	$injector->define('\App\Controller', [
		':response'	=> $response,
	]);

	// ...
	// some of your spaghetti code here
	// ...

	$request = Symfony\Component\HttpFoundation\Request::createFromGlobals();
	$injector->appendDefine('\App\Controller', [
		':request'	=> $request
	]);



Override example

	// Default case
	$injector->define('\App\Someclass', [
		':result'	=> $successResult,
	]);

	try {
		// ...
		// some checks throw an exception
		// ...
	} catch (\Exception $e) {
		$exceptionResult = new \ExceptionResult($e)
		$injector->appendDefine('\App\Someclass', [
			':result'	=> $exceptionResult
		]);
	}
