### PR TITLE
Fix "trying to get property of non-object" notice when a delegate closure has no class scope

### DIFF
--- a/lib/Executable.php
+++ b/lib/Executable.php
@@ -48,11 +48,11 @@ class Executable {
      */
     private function invokeClosureCompat($reflection, $args) {
         if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-            $class_scope = $reflection->getClosureScopeClass();
+            $classScope = $reflection->getClosureScopeClass();
             $closure = \Closure::bind(
                 $reflection->getClosure(),
                 $reflection->getClosureThis(),
-                $class_scope ? $class_scope->name : null
+                $classScope ? $classScope->name : null
             );
             return call_user_func_array($closure, $args);
         } else {

--- a/lib/Executable.php
+++ b/lib/Executable.php
@@ -48,10 +48,11 @@ class Executable {
      */
     private function invokeClosureCompat($reflection, $args) {
         if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+            $class_scope = $reflection->getClosureScopeClass();
             $closure = \Closure::bind(
                 $reflection->getClosure(),
                 $reflection->getClosureThis(),
-                $reflection->getClosureScopeClass()->name
+                $class_scope ? $class_scope->name : null
             );
             return call_user_func_array($closure, $args);
         } else {


### PR DESCRIPTION
When the passed closure has no class scope, ReflectionMethod::getClosureScopeClass() returns null instead of a ReflectionClass.  This change seems safe, but I'm unsure about expressly passing null into Closure::bind vs the string 'static' which is what the manual suggests should be passed instead.