### PR TITLE
Fix 'get property on non-object' notice.

### DIFF
--- a/lib/Executable.php
+++ b/lib/Executable.php
@@ -48,11 +48,19 @@ class Executable {
      */
     private function invokeClosureCompat($reflection, $args) {
         if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-            $closure = \Closure::bind(
-                $reflection->getClosure(),
-                $reflection->getClosureThis(),
-                $reflection->getClosureScopeClass()->name
-            );
+            if ($reflection->getClosureScopeClass()) {
+                $closure = \Closure::bind(
+                    $reflection->getClosure(),
+                    $reflection->getClosureThis(),
+                    $reflection->getClosureScopeClass()
+                );
+            } else {
+                $closure = \Closure::bind(
+                    $reflection->getClosure(),
+                    $reflection->getClosureThis()
+                );
+            }
+
             return call_user_func_array($closure, $args);
         } else {
             return $reflection->invokeArgs($args);


### PR DESCRIPTION
It is possible for ReflectionFunction::getClosureScopeCLass()
to return NULL, at which point there is no name property to get.

Since Closure::bind() does not require the third property this
leaves it out if there is no scope class for the closure.