### PR TITLE
Fix a fatal and a warning

### DIFF
--- a/lib/Executable.php
+++ b/lib/Executable.php
@@ -48,10 +48,11 @@ class Executable {
      */
     private function invokeClosureCompat($reflection, $args) {
         if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+			$scope = $reflection->getClosureScopeClass();
             $closure = \Closure::bind(
                 $reflection->getClosure(),
                 $reflection->getClosureThis(),
-                $reflection->getClosureScopeClass()->name
+                $scope ? $scope->name : null
             );
             return call_user_func_array($closure, $args);
         } else {

--- a/lib/Executable.php
+++ b/lib/Executable.php
@@ -48,7 +48,7 @@ class Executable {
      */
     private function invokeClosureCompat($reflection, $args) {
         if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-			$scope = $reflection->getClosureScopeClass();
+            $scope = $reflection->getClosureScopeClass();
             $closure = \Closure::bind(
                 $reflection->getClosure(),
                 $reflection->getClosureThis(),

--- a/lib/StandardReflector.php
+++ b/lib/StandardReflector.php
@@ -10,7 +10,7 @@ class StandardReflector implements Reflector {
     public function getCtor($class) {
         $reflectionClass = new \ReflectionClass($class);
 
-        return $reflectionClass->getCtor();
+        return $reflectionClass->getConstructor();
     }
 
     public function getCtorParams($class) {


### PR DESCRIPTION
Warning: possible dereference of null object

Fatal: reflection getCtor() -> getConstructor() typo in the std reflector