### PR TITLE
Allow custom definition args to be passed through to delegate function.

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -415,7 +415,7 @@ class Injector {
             } elseif (($prefix = self::A_DEFINE . $name) && isset($definition[$prefix])) {
                 // interpret the param as a class definition
                 $arg = $this->buildArgFromParamDefineArr($definition[$prefix]);
-            } elseif (!$arg = $this->buildArgFromTypeHint($reflFunc, $reflParam)) {
+            } elseif (!$arg = $this->buildArgFromTypeHint($reflFunc, $reflParam, $definition)) {
                 $arg = $this->buildArgFromReflParam($reflParam);
             }
 
@@ -456,13 +456,19 @@ class Injector {
         return $executable($paramName, $this);
     }
 
-    private function buildArgFromTypeHint(\ReflectionFunctionAbstract $reflFunc, \ReflectionParameter $reflParam) {
+    private function buildArgFromTypeHint(
+        \ReflectionFunctionAbstract $reflFunc,
+        \ReflectionParameter $reflParam,
+        array $definition
+    ) {
         $typeHint = $this->reflector->getParamTypeHint($reflFunc, $reflParam);
 
         if (!$typeHint) {
             $obj = null;
         } elseif ($reflParam->isDefaultValueAvailable()) {
             $obj = $reflParam->getDefaultValue();
+        } elseif (array_key_exists($typeHint, $definition)) {
+            $obj = $definition[$typeHint];
         } else {
             $obj = $this->make($typeHint);
         }

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -323,7 +323,6 @@ class Injector {
 
         if (isset($this->delegates[$normalizedClass])) {
             $executable = $this->buildExecutable($this->delegates[$normalizedClass]);
-
             $reflectionFunction = $executable->getCallableReflection();
             $args = $this->provisionFuncArgs($reflectionFunction, $args);
             $obj = call_user_func_array(array($executable, '__invoke'), $args);

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -788,17 +788,22 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
 
     public function testDelegationCustomArg() {
         $value = 'custom value';
-        $depdency = new \Auryn\Test\TestDelegateCustomArgDependency;
-        $depdency->value = $value;
-
-        $injector = new Injector();
-        $injector->delegate(
-            'Auryn\Test\TestDelegateCustomArg',
-            'Auryn\Test\createTestDelegateCustomArg'
-        );
-        $customArgs = ['Auryn\Test\TestDelegateCustomArgDependency' => $depdency];
-        $obj = $injector->make('Auryn\Test\TestDelegateCustomArg', $customArgs);
-        $this->assertInstanceOf('Auryn\Test\TestDelegateCustomArg', $obj);
-        $this->assertEquals($value, $obj->dependency->value);
+        $dependency = new \Auryn\Test\TestDelegateCustomArgDependency;
+        $dependency->value = $value;
+        
+        $customArgsByType = ['Auryn\Test\TestDelegateCustomArgDependency' => $dependency];
+        $customArgsByName = [':dependency' => $dependency];
+        $setCustomArgs = [$customArgsByType, $customArgsByName];
+        
+        foreach ($setCustomArgs as $customArgs) {
+            $injector = new Injector();
+            $injector->delegate(
+                'Auryn\Test\TestDelegateCustomArg',
+                'Auryn\Test\createTestDelegateCustomArg'
+            );
+            $obj = $injector->make('Auryn\Test\TestDelegateCustomArg', $customArgs);
+            $this->assertInstanceOf('Auryn\Test\TestDelegateCustomArg', $obj);
+            $this->assertEquals($value, $obj->dependency->value);
+        }
     }
 }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -785,4 +785,20 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('Auryn\Test\TestDelegationDependency', $obj);
         $this->assertTrue($obj->delegateCalled);
     }
+
+    public function testDelegationCustomArg() {
+        $value = 'custom value';
+        $depdency = new \Auryn\Test\TestDelegateCustomArgDependency;
+        $depdency->value = $value;
+
+        $injector = new Injector();
+        $injector->delegate(
+            'Auryn\Test\TestDelegateCustomArg',
+            'Auryn\Test\createTestDelegateCustomArg'
+        );
+        $customArgs = ['Auryn\Test\TestDelegateCustomArgDependency' => $depdency];
+        $obj = $injector->make('Auryn\Test\TestDelegateCustomArg', $customArgs);
+        $this->assertInstanceOf('Auryn\Test\TestDelegateCustomArg', $obj);
+        $this->assertEquals($value, $obj->dependency->value);
+    }
 }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -447,3 +447,18 @@ function createTestDelegationDependency(TestDelegationSimple $testDelegationSimp
 
     return $instance;
 }
+
+class TestDelegateCustomArgDependency {
+    public $value = 'not set';
+}
+
+class TestDelegateCustomArg {
+    public $dependency;
+    public function __construct(TestDelegateCustomArgDependency $dependency) {
+        $this->dependency = $dependency;
+    }
+}
+
+function createTestDelegateCustomArg(TestDelegateCustomArgDependency $dependency) {
+    return new TestDelegateCustomArg($dependency);
+}


### PR DESCRIPTION
This is one to probably think about before merging - it addresses #78, and I'll put the reason why I think it's the right behaviour there.