### PR TITLE
Executing aliased classes should use the aliased class.

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -601,9 +601,19 @@ class Injector {
 
         $reflectionMethod = $this->reflector->getMethod($class, $method);
 
-        return $reflectionMethod->isStatic()
-            ? array($reflectionMethod, null)
-            : array($reflectionMethod, $this->make($class));
+        if ($reflectionMethod->isStatic()) {
+            return array($reflectionMethod, NULL);
+        }
+
+        $instance = $this->make($class);
+        // If the class was aliased, the instance will not be of the type
+        // $class but some other type. We need to get the reflection on the
+        // actual class to be able to call the method correctly.
+        if ($class !== get_class($instance)) {
+            $reflectionMethod = $this->reflector->getMethod($instance, $method);
+        }
+
+        return array($reflectionMethod, $instance);
     }
 
     private function buildExecutableStructFromArray($arrayExecutable) {

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -599,25 +599,14 @@ class Injector {
             $method = substr($method, $relativeStaticMethodStartPos + 8);
         }
 
-        $reflectionMethod = $this->reflector->getMethod($class, $method);
+        list($className, $normalizedClass) = $this->resolveAlias($class);
+        $reflectionMethod = $this->reflector->getMethod($normalizedClass, $method);
 
-        $instance = NULL;
         if ($reflectionMethod->isStatic()) {
-            list($resolvedClass, ) = $this->resolveAlias($class);
+            return array($reflectionMethod, NULL);
+        } else {
+            return array($reflectionMethod, $this->make($className));
         }
-        else {
-            $instance = $this->make($class);
-            $resolvedClass = get_class($instance);
-        }
-
-        // If the class was aliased, the instance will not be of the type
-        // $class but some other type. We need to get the reflection on the
-        // actual class to be able to call the method correctly.
-        if ($class !== $resolvedClass) {
-            $reflectionMethod = $this->reflector->getMethod($resolvedClass, $method);
-        }
-
-        return array($reflectionMethod, $instance);
     }
 
     private function buildExecutableStructFromArray($arrayExecutable) {

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -601,16 +601,20 @@ class Injector {
 
         $reflectionMethod = $this->reflector->getMethod($class, $method);
 
+        $instance = NULL;
         if ($reflectionMethod->isStatic()) {
-            return array($reflectionMethod, NULL);
+            list($resolvedClass, ) = $this->resolveAlias($class);
+        }
+        else {
+            $instance = $this->make($class);
+            $resolvedClass = get_class($instance);
         }
 
-        $instance = $this->make($class);
         // If the class was aliased, the instance will not be of the type
         // $class but some other type. We need to get the reflection on the
         // actual class to be able to call the method correctly.
-        if ($class !== get_class($instance)) {
-            $reflectionMethod = $this->reflector->getMethod($instance, $method);
+        if ($class !== $resolvedClass) {
+            $reflectionMethod = $this->reflector->getMethod($resolvedClass, $method);
         }
 
         return array($reflectionMethod, $instance);

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -789,7 +789,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
     public function testExecutableAliasing() {
         $injector = new Injector();
         $injector->alias('Auryn\Test\BaseExecutableClass', 'Auryn\Test\ExtendsExecutableClass');
-        $result = $injector->execute(['Auryn\Test\BaseExecutableClass', 'foo']);
+        $result = $injector->execute(array('Auryn\Test\BaseExecutableClass', 'foo'));
         $this->assertEquals('This is the ExtendsExecutableClass', $result);
     }
 }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -792,4 +792,12 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
         $result = $injector->execute(array('Auryn\Test\BaseExecutableClass', 'foo'));
         $this->assertEquals('This is the ExtendsExecutableClass', $result);
     }
+
+    public function testExecutableAliasingStatic() {
+        $injector = new Injector();
+        $injector->alias('Auryn\Test\BaseExecutableClass', 'Auryn\Test\ExtendsExecutableClass');
+        $result = $injector->execute(array('Auryn\Test\BaseExecutableClass', 'bar'));
+        $this->assertEquals('This is the ExtendsExecutableClass', $result);
+    }
+    
 }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -785,4 +785,11 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('Auryn\Test\TestDelegationDependency', $obj);
         $this->assertTrue($obj->delegateCalled);
     }
+
+    public function testExecutableAliasing() {
+        $injector = new Injector();
+        $injector->alias('Auryn\Test\BaseExecutableClass', 'Auryn\Test\ExtendsExecutableClass');
+        $result = $injector->execute(['Auryn\Test\BaseExecutableClass', 'foo']);
+        $this->assertEquals('This is the ExtendsExecutableClass', $result);
+    }
 }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -447,3 +447,16 @@ function createTestDelegationDependency(TestDelegationSimple $testDelegationSimp
 
     return $instance;
 }
+
+
+class BaseExecutableClass {
+    function foo() {
+        return 'This is the BaseExecutableClass';
+    }
+}
+
+class ExtendsExecutableClass extends BaseExecutableClass {
+    function foo() {
+        return 'This is the ExtendsExecutableClass';
+    }
+}

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -453,10 +453,16 @@ class BaseExecutableClass {
     function foo() {
         return 'This is the BaseExecutableClass';
     }
+    static function bar() {
+        return 'This is the BaseExecutableClass';
+    }
 }
 
 class ExtendsExecutableClass extends BaseExecutableClass {
     function foo() {
+        return 'This is the ExtendsExecutableClass';
+    }
+    static function bar() {
         return 'This is the ExtendsExecutableClass';
     }
 }


### PR DESCRIPTION
Fixes #61. 

i.e. it makes this code:

```
$injector->execute(['Foo', 'bar']);
```

behave the same as this code:

```
$instance = $injector->make('Foo');
$injector->execute([$instance, 'bar']);
```
even when Foo has been aliased to some other class. The correct object was being made, but due to the magic of PHP's reflection system, the wrong method is called, like in http://3v4l.org/pOagM


