### PR TITLE
Use specified case for classes.

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -600,7 +600,7 @@ class Injector {
         }
 
         list($className, $normalizedClass) = $this->resolveAlias($class);
-        $reflectionMethod = $this->reflector->getMethod($normalizedClass, $method);
+        $reflectionMethod = $this->reflector->getMethod($className, $method);
 
         return $reflectionMethod->isStatic()
             ? array($reflectionMethod, null)


### PR DESCRIPTION
Need to use specified case to allow class loading to work on case sensitive filesystems.