### PR TITLE
Allow params with types and default to be injected correctly.

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -461,7 +461,15 @@ class Injector {
         if (!$typeHint) {
             $obj = null;
         } elseif ($reflParam->isDefaultValueAvailable()) {
-            $obj = $reflParam->getDefaultValue();
+            $normalizedName = $this->normalizeName($typeHint);
+            // Injector has been told explicitly how to make this type
+            if (isset($this->aliases[$normalizedName]) ||
+                isset($this->delegates[$normalizedName]) ||
+                isset($this->shares[$normalizedName])) {
+                $obj = $this->make($typeHint);
+            } else {
+                $obj = $reflParam->getDefaultValue();
+            }
         } else {
             $obj = $this->make($typeHint);
         }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -614,11 +614,43 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
         $injector->make($class);
     }
 
-    public function testNonConcreteDependencyWithDefaultValue() {
+    public function testNonConcreteDependencyWithDefault() {
         $injector = new Injector;
         $class = $injector->make('Auryn\Test\NonConcreteDependencyWithDefaultValue');
         $this->assertInstanceOf('Auryn\Test\NonConcreteDependencyWithDefaultValue', $class);
         $this->assertNull($class->interface);
+    }
+
+    public function testNonConcreteDependencyWithDefaultValueThroughAlias() {
+        $injector = new Injector;
+        $injector->alias(
+            'Auryn\Test\DelegatableInterface',
+            'Auryn\Test\ImplementsInterface'
+        );
+        $class = $injector->make('Auryn\Test\NonConcreteDependencyWithDefaultValue');
+        $this->assertInstanceOf('Auryn\Test\NonConcreteDependencyWithDefaultValue', $class);
+        $this->assertInstanceOf('Auryn\Test\ImplementsInterface', $class->interface);
+    }
+
+    public function testNonConcreteDependencyWithDefaultValueThroughDelegation() {
+        $injector = new Injector;
+        $injector->delegate('Auryn\Test\DelegatableInterface', 'Auryn\Test\ImplementsInterfaceFactory');
+        $class = $injector->make('Auryn\Test\NonConcreteDependencyWithDefaultValue');
+        $this->assertInstanceOf('Auryn\Test\NonConcreteDependencyWithDefaultValue', $class);
+        $this->assertInstanceOf('Auryn\Test\ImplementsInterface', $class->interface);
+    }
+
+    public function testDependencyWithDefaultValueThroughShare() {
+        $injector = new Injector;
+        //Instance is not shared, null default is used for dependency
+        $instance = $injector->make('Auryn\Test\ConcreteDependencyWithDefaultValue');
+        $this->assertNull($instance->dependency);
+
+        //Instance is explicitly shared, $instance is used for dependency
+        $instance = new \StdClass();
+        $injector->share($instance);
+        $instance = $injector->make('Auryn\Test\ConcreteDependencyWithDefaultValue');
+        $this->assertInstanceOf('StdClass', $instance->dependency);
     }
 
     /**

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -360,6 +360,14 @@ class NonConcreteDependencyWithDefaultValue {
     }
 }
 
+
+class ConcreteDependencyWithDefaultValue {
+    public $dependency;
+    function __construct(\StdClass $instance = NULL) {
+        $this->dependency = $instance;
+    }
+}
+
 class TypelessParameterDependency {
 
     public $thumbnailSize;


### PR DESCRIPTION
I believe the correct behaviour when parameter has both a type and a default value (which currently can only be null), is to inject the dependency if the injector has been explicitly told to do so through either alias, delegate or share. Currently if a parameter has both a type and a default of null, autowiring of the constructor cannot be done, and instead a custom function to create the class is required to work around the limitation.This fixes #67.


An example of the work-around code needed without this PR is
https://github.com/rdlowrey/Auryn/issues/67#issuecomment-49488794
