### PR TITLE
Abstract class execute

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -614,9 +614,17 @@ class Injector {
         list($className, $normalizedClass) = $this->resolveAlias($class);
         $reflectionMethod = $this->reflector->getMethod($className, $method);
 
-        return $reflectionMethod->isStatic()
-            ? array($reflectionMethod, null)
-            : array($reflectionMethod, $this->make($className));
+        if ($reflectionMethod->isStatic()) {
+            return array($reflectionMethod, null);
+        }
+
+        $instance = $this->make($className);
+        // If the class was delegated, the instance may not be of the type
+        // $class but some other type. We need to get the reflection on the
+        // actual class to be able to call the method correctly.
+        $reflectionMethod = $this->reflector->getMethod($instance, $method);
+
+        return array($reflectionMethod, $instance);
     }
 
     private function buildExecutableStructFromArray($arrayExecutable) {

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -871,4 +871,17 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
         $newInjector = $instance->injector;
         $newInstance = $newInjector->make('Auryn\Test\CloneTest');
     }
+    
+    public function testAbstractExecute() {
+        $injector = new Injector();
+
+        $fn = function () {
+            return new \Auryn\Test\ConcreteExexcuteTest();
+        };
+
+        $injector->delegate('Auryn\Test\AbstractExecuteTest', $fn);        
+        $result = $injector->execute(['Auryn\Test\AbstractExecuteTest', 'process']);
+
+        $this->assertEquals('Concrete', $result);
+    }
 }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -880,7 +880,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
         };
 
         $injector->delegate('Auryn\Test\AbstractExecuteTest', $fn);        
-        $result = $injector->execute(['Auryn\Test\AbstractExecuteTest', 'process']);
+        $result = $injector->execute(array('Auryn\Test\AbstractExecuteTest', 'process'));
 
         $this->assertEquals('Concrete', $result);
     }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -505,4 +505,15 @@ class CloneTest {
         $this->injector = clone $injector;
     }
 }
-    
+
+abstract class AbstractExecuteTest {
+    function process() {
+        return "Abstract";
+    }
+}
+
+class ConcreteExexcuteTest extends AbstractExecuteTest {
+    function process() {
+        return "Concrete";
+    }
+}


### PR DESCRIPTION
When doing execute on an abstract class, that is delegated to a function that returns a concrete instance, the ReflectionMethod needs to be from the instantiated class not the class that was requested.

It's possible that this could be optimized, e.g. to only do the reflection if delegate[] for the requested class is set, but I didn't include that.