### PR TITLE
Delegate error message

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -32,7 +32,7 @@ class Injector {
     const E_UNDEFINED_PARAM = 9;
     const M_UNDEFINED_PARAM = "No definition available to provision typeless parameter \$%s at position %d in %s()";
     const E_DELEGATE_ARGUMENT = 10;
-    const M_DELEGATE_ARGUMENT = "%s::delegate expects a valid callable or executable class::method string at Argument 2";
+    const M_DELEGATE_ARGUMENT = "%s::delegate expects a valid callable or executable class::method string at Argument 2%s";
     const E_CYCLIC_DEPENDENCY = 11;
     const M_CYCLIC_DEPENDENCY = "Detected a cyclic dependency while provisioning %s";
 
@@ -239,8 +239,21 @@ class Injector {
      */
     public function delegate($name, $callableOrMethodStr) {
         if ($this->isExecutable($callableOrMethodStr) === false) {
+            $errorDetail = '';
+            if (is_string($callableOrMethodStr)) {
+                $errorDetail = " but received '$callableOrMethodStr'";
+            }
+            else if (is_array($callableOrMethodStr) && 
+                count($callableOrMethodStr) == 2 && 
+                array_key_exists(0, $callableOrMethodStr) &&
+                array_key_exists(1, $callableOrMethodStr)) {
+                if (is_string($callableOrMethodStr[0]) && is_string($callableOrMethodStr[1])) {
+                    $errorDetail = " but received ['".$callableOrMethodStr[0]."', '".$callableOrMethodStr[1]."']";
+                }
+            }
+
             throw new InjectorException(
-                sprintf(self::M_DELEGATE_ARGUMENT, __CLASS__),
+                sprintf(self::M_DELEGATE_ARGUMENT, __CLASS__, $errorDetail),
                 self::E_DELEGATE_ARGUMENT
             );
         }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -333,7 +333,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
     public function testUnknownDelegationMethod() {
         $injector = new Injector;
         try {
-            $injector->delegate('Auryn\Test\DelegatableInterface', ['stdClass', 'methodWhichDoesNotExist']);
+            $injector->delegate('Auryn\Test\DelegatableInterface', array('stdClass', 'methodWhichDoesNotExist'));
             $this->fail("Delegation was supposed to fail.");
         }
         catch(\Auryn\InjectorException $ie) {

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -318,6 +318,31 @@ class InjectorTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceof('Auryn\Test\MadeByDelegate', $injector->make('Auryn\Test\MadeByDelegate'));
     }
 
+    public function testUnknownDelegationFunction() {
+        $injector = new Injector;
+        try {
+            $injector->delegate('Auryn\Test\DelegatableInterface', 'FunctionWhichDoesNotExist');
+            $this->fail("Delegation was supposed to fail.");
+        }
+        catch(\Auryn\InjectorException $ie) {
+            $this->assertContains('FunctionWhichDoesNotExist', $ie->getMessage());
+            $this->assertEquals(\Auryn\Injector::E_DELEGATE_ARGUMENT, $ie->getCode());
+        }
+    }
+
+    public function testUnknownDelegationMethod() {
+        $injector = new Injector;
+        try {
+            $injector->delegate('Auryn\Test\DelegatableInterface', ['stdClass', 'methodWhichDoesNotExist']);
+            $this->fail("Delegation was supposed to fail.");
+        }
+        catch(\Auryn\InjectorException $ie) {
+            $this->assertContains('stdClass', $ie->getMessage());
+            $this->assertContains('methodWhichDoesNotExist', $ie->getMessage());
+            $this->assertEquals(\Auryn\Injector::E_DELEGATE_ARGUMENT, $ie->getCode());
+        }
+    }
+
     /**
      * @dataProvider provideExecutionExpectations
      */


### PR DESCRIPTION
This now gives actual information when the variable is a string or [classname, methodname] but not actually callable.