### PR TITLE
Adds test for inspecting shares

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -302,6 +302,7 @@ class Injector
             self::I_ALIASES => "aliases",
             self::I_SHARES => "shares"
         );
+
         foreach ($types as $type => $source) {
             if ($typeFilter & $type) {
                 $result[$type] = $this->filter($this->{$source}, $name);
@@ -315,8 +316,8 @@ class Injector
     {
         if (empty($name)) {
             return $source;
-        } elseif (isset($source[$name])) {
-            return $source[$name];
+        } elseif (array_key_exists($name, $source)) {
+            return [$name => $source[$name]];
         } else {
             return array();
         }

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -317,7 +317,7 @@ class Injector
         if (empty($name)) {
             return $source;
         } elseif (array_key_exists($name, $source)) {
-            return [$name => $source[$name]];
+            return array($name => $source[$name]);
         } else {
             return array();
         }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1000,4 +1000,14 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('auryn\test\depinterface', $chain[1]);
         }
     }
+
+    public function testInspectShares()
+    {
+        $injector = new Injector();
+        $injector->share(\Auryn\Test\SomeClassName::class);
+
+        $expectedKey = strtolower(\Auryn\Test\SomeClassName::class);
+        $inspection = $injector->inspect(\Auryn\Test\SomeClassName::class, Injector::I_SHARES)[Injector::I_SHARES];
+        $this->assertArrayHasKey($expectedKey, $inspection);
+    }
 }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1004,10 +1004,9 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
     public function testInspectShares()
     {
         $injector = new Injector();
-        $injector->share(\Auryn\Test\SomeClassName::class);
+        $injector->share('Auryn\Test\SomeClassName');
 
-        $expectedKey = strtolower(\Auryn\Test\SomeClassName::class);
-        $inspection = $injector->inspect(\Auryn\Test\SomeClassName::class, Injector::I_SHARES)[Injector::I_SHARES];
-        $this->assertArrayHasKey($expectedKey, $inspection);
+        $inspection = $injector->inspect('Auryn\Test\SomeClassName', Injector::I_SHARES);
+        $this->assertArrayHasKey('auryn\test\someclassname', $inspection[Injector::I_SHARES]);
     }
 }


### PR DESCRIPTION
This changes the isset() check to an array_key_exists check for the 
filter method. If a class is shared but has no definition the shares element 
for that key is null; this causes the isset() check to fail and the specific type
information is not returned, although it does exist.