### PR TITLE
Add check for when making an object has failed.

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -367,11 +367,11 @@ class Injector
             $obj = $this->provisionInstance($className, $normalizedClass, $args);
         }
 
+        $this->prepareInstance($obj, $normalizedClass);
+
         if (array_key_exists($normalizedClass, $this->shares)) {
             $this->shares[$normalizedClass] = $obj;
         }
-
-        $this->prepareInstance($obj, $normalizedClass);
 
         unset($this->inProgressMakes[$normalizedClass]);
 

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -580,11 +580,13 @@ class Injector
             );
         }
 
-        $interfaces = array_flip(array_map(array($this, 'normalizeName'), $interfaces));
-        $prepares = array_intersect_key($this->prepares, $interfaces);
-        foreach ($prepares as $prepare) {
-            $executable = $this->buildExecutable($prepare);
-            $executable($obj, $this);
+        if ($interfaces) {
+            $interfaces = array_flip(array_map(array($this, 'normalizeName'), $interfaces));
+            $prepares = array_intersect_key($this->prepares, $interfaces);
+            foreach ($prepares as $prepare) {
+                $executable = $this->buildExecutable($prepare);
+                $executable($obj, $this);
+            }
         }
     }
 

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1009,4 +1009,18 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $inspection = $injector->inspect('Auryn\Test\SomeClassName', Injector::I_SHARES);
         $this->assertArrayHasKey('auryn\test\someclassname', $inspection[Injector::I_SHARES]);
     }
+
+    /**
+     * @expectedException \Auryn\InjectionException
+     * @expectedExceptionCode \Auryn\Injector::E_MAKING_FAILED
+     */
+    public function testDelegationDoesntMakeObject()
+    {
+        $delegate = function () {
+            return null;
+        };
+        $injector = new Injector();
+        $injector->delegate('Auryn\Test\SomeClassName', $delegate);
+        $injector->make('Auryn\Test\SomeClassName');
+    }
 }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1023,4 +1023,18 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $injector->delegate('Auryn\Test\SomeClassName', $delegate);
         $injector->make('Auryn\Test\SomeClassName');
     }
+
+    /**
+     * @expectedException \Auryn\InjectionException
+     * @expectedExceptionCode \Auryn\Injector::E_MAKING_FAILED
+     */
+    public function testDelegationDoesntMakeObjectMakesString()
+    {
+        $delegate = function () {
+            return 'ThisIsNotAClass';
+        };
+        $injector = new Injector();
+        $injector->delegate('Auryn\Test\SomeClassName', $delegate);
+        $injector->make('Auryn\Test\SomeClassName');
+    }
 }


### PR DESCRIPTION
Typically this happens when someone delegates to a function, and then forgets to return an object from that delegate.

fyi It has a small performance implication but is barely measurable on my machine. Allegedly the error suppression is 'expensive'.

Also, I am not sure I can actually English today, so the error message might need improvement.