### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ var_dump($obj->value); // int(2)
 ### Prepares and Setter Injection
 
 Constructor injection is almost always preferable to setter injection. However, some APIs require
-additional post-instantiation mutations. auryn accomodates these use cases with its
+additional post-instantiation mutations. auryn accommodates these use cases with its
 `Injector::prepare()` method. Users may register any class or interface name for post-instantiation
 modification. Consider:
 


### PR DESCRIPTION
rdlowrey, I've corrected a typographical error in the documentation of the [auryn](https://github.com/rdlowrey/auryn) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.