### PR TITLE
Use constructors' class for definition lookups

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -364,7 +364,7 @@ class Injector
             $args = $this->provisionFuncArgs($reflectionFunction, $args);
             $obj = call_user_func_array(array($executable, '__invoke'), $args);
         } else {
-            $obj = $this->provisionInstance($className, $normalizedClass, $args);
+            $obj = $this->provisionInstance($className, $args);
         }
 
         $obj = $this->prepareInstance($obj, $normalizedClass);
@@ -378,7 +378,7 @@ class Injector
         return $obj;
     }
 
-    private function provisionInstance($className, $normalizedClass, array $definition)
+    private function provisionInstance($className, array $definition)
     {
         try {
             $ctor = $this->reflector->getCtor($className);
@@ -393,9 +393,12 @@ class Injector
                 );
             } elseif ($ctorParams = $this->reflector->getCtorParams($className)) {
                 $reflClass = $this->reflector->getClass($className);
-                $definition = isset($this->classDefinitions[$normalizedClass])
-                    ? array_replace($this->classDefinitions[$normalizedClass], $definition)
+
+                $normalizedCtorClass = $this->normalizeName($ctor->class);
+                $definition = isset($this->classDefinitions[$normalizedCtorClass])
+                    ? array_replace($this->classDefinitions[$normalizedCtorClass], $definition)
                     : $definition;
+
                 $args = $this->provisionFuncArgs($ctor, $definition, $ctorParams);
                 $obj = $reflClass->newInstanceArgs($args);
             } else {


### PR DESCRIPTION
This one is a "not sure if on purpose" thing.

In the case where a constructor is defined in the parent of a class being instantiated, and not overridden, the parent class should be used when looking up argument definitions.

For example with the following class definitions
```
class AwsClient {
    public function __construct(array $args) {}
}

class CloudWatchClient extends AwsClient {}

class MyClass
{
    function __construct(CloudWatchClient $cloudWatchClient) {}
}
```

Then instantiating as follows:
```
$injector->share('AwsClient');
$injector->define('AwsClient', [
    ':args' => [
        'version' => 'latest',
        'region' => 'eu-west-1'
    ]
]);

$injector->make("MyClass");
```

Gives
`No definition available to provision typeless parameter $args at position 0 in AwsClient::__construct()' in .../vendor/rdlowrey/auryn/lib/Injector.php on line 546`

Unsure if similar handling is needed elsewhere. Not really familiar with the codebase anymore