### PR TITLE
Improve exception messages for invalid callables

### DIFF
--- a/lib/InjectionException.php
+++ b/lib/InjectionException.php
@@ -16,10 +16,6 @@ class InjectionException extends InjectorException
 
     /**
      * Add a human readable version of the invalid callable to the standard 'invalid invokable' message.
-     * @param array $inProgressMakes
-     * @param $callableOrMethodStr
-     * @param \Exception $previous
-     * @return InjectionException
      */
     public static function fromInvalidCallable(
         array $inProgressMakes,

--- a/lib/InjectionException.php
+++ b/lib/InjectionException.php
@@ -15,6 +15,51 @@ class InjectionException extends InjectorException
     }
 
     /**
+     * Add a human readable version of the invalid callable to the standard 'invalid invokable' message.
+     * @param array $inProgressMakes
+     * @param $callableOrMethodStr
+     * @param \Exception $previous
+     * @return InjectionException
+     */
+    public static function fromInvalidCallable(
+        array $inProgressMakes,
+        $callableOrMethodStr,
+        \Exception $previous = null
+    ) {
+        $callableString = null;
+
+        if (is_string($callableOrMethodStr)) {
+            $callableString .= $callableOrMethodStr;
+        } else if (is_array($callableOrMethodStr) && 
+            array_key_exists(0, $callableOrMethodStr) &&
+            array_key_exists(0, $callableOrMethodStr)) {
+            if (is_string($callableOrMethodStr[0]) && is_string($callableOrMethodStr[1])) {
+                $callableString .= $callableOrMethodStr[0].'::'.$callableOrMethodStr[1];
+            } else if (is_object($callableOrMethodStr[0]) && is_string($callableOrMethodStr[1])) {
+                $callableString .= sprintf(
+                    "[object(%s), '%s']",
+                    get_class($callableOrMethodStr[0]),
+                    $callableOrMethodStr[1]
+                );
+            }
+        }
+
+        if ($callableString) {
+            // Prevent accidental usage of long strings from filling logs. 
+            $callableString = substr($callableString, 0, 250);
+            $message = sprintf(
+                "%s. Invalid callable was '%s'",
+                Injector::M_INVOKABLE,
+                $callableString
+            );
+        } else {
+            $message = \Auryn\Injector::M_INVOKABLE;
+        }
+
+        return new self($inProgressMakes, $message, Injector::E_INVOKABLE, $previous);
+    }
+
+    /**
      * Returns the hierarchy of dependencies that were being created when
      * the exception occurred.
      * @return array

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -218,10 +218,10 @@ class Injector
     public function prepare($name, $callableOrMethodStr)
     {
         if ($this->isExecutable($callableOrMethodStr) === false) {
-            throw new InjectionException(
+            throw InjectionException::fromInvalidCallable(
                 $this->inProgressMakes,
-                self::M_INVOKABLE,
-                self::E_INVOKABLE
+                self::E_INVOKABLE,
+                $callableOrMethodStr
             );
         }
 
@@ -490,10 +490,9 @@ class Injector
     private function buildArgFromDelegate($paramName, $callableOrMethodStr)
     {
         if ($this->isExecutable($callableOrMethodStr) === false) {
-            throw new InjectionException(
+            throw InjectionException::fromInvalidCallable(
                 $this->inProgressMakes,
-                self::M_INVOKABLE,
-                self::E_INVOKABLE
+                $callableOrMethodStr
             );
         }
 
@@ -625,7 +624,15 @@ class Injector
      */
     public function buildExecutable($callableOrMethodStr)
     {
-        list($reflFunc, $invocationObj) = $this->buildExecutableStruct($callableOrMethodStr);
+        try {
+            list($reflFunc, $invocationObj) = $this->buildExecutableStruct($callableOrMethodStr);
+        } catch (\ReflectionException $e) {
+            throw InjectionException::fromInvalidCallable(
+                $this->inProgressMakes,
+                $callableOrMethodStr,
+                $e
+            );
+        }
 
         return new Executable($reflFunc, $invocationObj);
     }
@@ -647,10 +654,9 @@ class Injector
         ) {
             $executableStruct = $this->buildExecutableStructFromArray($callableOrMethodStr);
         } else {
-            throw new InjectionException(
+            throw InjectionException::fromInvalidCallable(
                 $this->inProgressMakes,
-                self::M_INVOKABLE,
-                self::E_INVOKABLE
+                $callableOrMethodStr
             );
         }
 
@@ -670,10 +676,9 @@ class Injector
             list($class, $method) = explode('::', $stringExecutable, 2);
             $executableStruct = $this->buildStringClassMethodCallable($class, $method);
         } else {
-            throw new InjectionException(
+            throw InjectionException::fromInvalidCallable(
                 $this->inProgressMakes,
-                self::M_INVOKABLE,
-                self::E_INVOKABLE
+                $stringExecutable
             );
         }
 
@@ -716,10 +721,9 @@ class Injector
         } elseif (is_string($classOrObj)) {
             $executableStruct = $this->buildStringClassMethodCallable($classOrObj, $method);
         } else {
-            throw new InjectionException(
+            throw InjectionException::fromInvalidCallable(
                 $this->inProgressMakes,
-                self::M_INVOKABLE,
-                self::E_INVOKABLE
+                $arrayExecutable
             );
         }
 

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -807,25 +807,38 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $injector->make('Auryn\Test\HasNonPublicConstructorWithArgs');
     }
 
-    /**
-     * @expectedException \Auryn\InjectionException
-     * @expectedExceptionCode \Auryn\Injector::E_INVOKABLE
-     */
     public function testMakeExecutableFailsOnNonExistentFunction()
     {
         $injector = new Injector();
+        $this->setExpectedException(
+            'Auryn\InjectionException',
+            'nonExistentFunction',
+            \Auryn\Injector::E_INVOKABLE
+        );
         $injector->buildExecutable('nonExistentFunction');
     }
 
-    /**
-     * @expectedException \Auryn\InjectionException
-     * @expectedExceptionCode \Auryn\Injector::E_INVOKABLE
-     */
-    public function testMakeExecutableFailsOnNonExistentMethod()
+    public function testMakeExecutableFailsOnNonExistentInstanceMethod()
     {
         $injector = new Injector();
         $object = new \StdClass();
-        $injector->buildExecutable(array($object, 'nonExistentFunction'));
+        $this->setExpectedException(
+            'Auryn\InjectionException',
+            "[object(stdClass), 'nonExistentMethod']",
+            \Auryn\Injector::E_INVOKABLE
+        );
+        $injector->buildExecutable(array($object, 'nonExistentMethod'));
+    }
+    
+    public function testMakeExecutableFailsOnNonExistentStaticMethod()
+    {
+        $injector = new Injector();
+        $this->setExpectedException(
+            'Auryn\InjectionException',
+            "StdClass::nonExistentMethod",
+            \Auryn\Injector::E_INVOKABLE
+        );
+        $injector->buildExecutable(['StdClass', 'nonExistentMethod']);
     }
 
     /**

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -838,7 +838,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
             "StdClass::nonExistentMethod",
             \Auryn\Injector::E_INVOKABLE
         );
-        $injector->buildExecutable(['StdClass', 'nonExistentMethod']);
+        $injector->buildExecutable(array('StdClass', 'nonExistentMethod'));
     }
 
     /**


### PR DESCRIPTION
I keep herp-derping while writing code, with typos in function names. This PR adds a human readable string of the callable in the cases where the 'invalid invokable' exception occurs.

It also fixes an issue where a bare ReflectionException escapes from the library without having been caught and turned into an Auryn specific exception.