### PR TITLE
Injection by reflection (and docblock if no type hinting was applied)

### DIFF
--- a/lib/ExtendedReflectionClass.php
+++ b/lib/ExtendedReflectionClass.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Auryn;
+
+class ExtendedReflectionClass extends \ReflectionClass
+{
+    /**
+     * Array of use statements for class.
+     *
+     * @var array
+     */
+    protected $useStatements = [];
+
+    /**
+     * Check if use statements have been parsed.
+     *
+     * @var boolean
+     */
+    protected $useStatementsParsed = false;
+
+    /**
+     * Parse class file and get use statements from current namespace.
+     *
+     * @return array
+     * @throws \RuntimeException
+     */
+    protected function parseUseStatements()
+    {
+        if ($this->useStatementsParsed) {
+            return $this->useStatements;
+        }
+
+        if (!$this->isUserDefined()) {
+            throw new \RuntimeException('Must parse use statements from user defined classes.');
+        }
+
+        $source                    = $this->readFileSource();
+        $this->useStatements       = $this->tokenizeSource($source);
+        $this->useStatementsParsed = true;
+
+        return $this->useStatements;
+    }
+
+    /**
+     * Read file source up to the line where our class is defined.
+     *
+     * @return string
+     */
+    private function readFileSource()
+    {
+        $file   = fopen($this->getFileName(), 'r');
+        $line   = 0;
+        $source = '';
+
+        while (!feof($file)) {
+            ++$line;
+
+            if ($line >= $this->getStartLine()) {
+                break;
+            }
+
+            $source .= fgets($file);
+        }
+
+        fclose($file);
+
+        return $source;
+    }
+
+    /**
+     * Parse the use statements from read source by
+     * tokenizing and reading the tokens. Returns
+     * an array of use statements and aliases.
+     *
+     * @param string $source
+     *
+     * @return array
+     */
+    private function tokenizeSource($source)
+    {
+        $tokens = token_get_all($source);
+
+        $builtNamespace    = '';
+        $buildingNamespace = false;
+        $matchedNamespace  = false;
+
+        $useStatements = [];
+        $record        = false;
+        $currentUse    = [
+            'class' => '',
+            'as'    => ''
+        ];
+
+        foreach ($tokens as $token) {
+
+            if ($token[0] === T_NAMESPACE) {
+                $buildingNamespace = true;
+
+                if ($matchedNamespace) {
+                    break;
+                }
+            }
+
+            if ($buildingNamespace) {
+
+                if ($token === ';') {
+                    $buildingNamespace = false;
+                    continue;
+                }
+
+                switch ($token[0]) {
+
+                    case T_STRING:
+                    case T_NS_SEPARATOR:
+                        $builtNamespace .= $token[1];
+                        break;
+                }
+
+                continue;
+            }
+
+            if ($token === ';' || !is_array($token)) {
+
+                if ($record) {
+                    $useStatements[] = $currentUse;
+                    $record          = false;
+                    $currentUse      = [
+                        'class' => '',
+                        'as'    => ''
+                    ];
+                }
+
+                continue;
+            }
+
+            if ($token[0] === T_CLASS) {
+                break;
+            }
+
+            if (strcasecmp($builtNamespace, $this->getNamespaceName()) === 0) {
+                $matchedNamespace = true;
+            }
+
+            if ($matchedNamespace) {
+
+                if ($token[0] === T_USE) {
+                    $record = 'class';
+                }
+
+                if ($token[0] === T_AS) {
+                    $record = 'as';
+                }
+
+                if ($record) {
+                    switch ($token[0]) {
+
+                        case T_STRING:
+                        case T_NS_SEPARATOR:
+
+                            if ($record) {
+                                $currentUse[$record] .= $token[1];
+                            }
+
+                            break;
+                    }
+                }
+            }
+
+            if ($token[2] >= $this->getStartLine()) {
+                break;
+            }
+        }
+
+        // Make sure the as key has the name of the class even
+        // if there is no alias in the use statement.
+        foreach ($useStatements as $k => $useStatement) {
+
+            $useStatements[(new \ReflectionClass($useStatement['class']))->getShortName()] = $useStatement['class'];
+            unset($useStatements[$k]);
+        }
+
+        return $useStatements;
+    }
+
+    /**
+     * Return array of use statements from class.
+     *
+     * @return array
+     */
+    public function getUseStatements()
+    {
+        return $this->parseUseStatements();
+    }
+
+    /**
+     * Check if class is using a class or an alias of a class.
+     *
+     * @param string $class
+     *
+     * @return boolean
+     */
+    public function hasUseStatement($class)
+    {
+        foreach ($this->parseUseStatements() as $shortName => $fqcn) {
+
+            if (($class === $shortName) || ($class === $fqcn)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/lib/StandardReflector.php
+++ b/lib/StandardReflector.php
@@ -2,16 +2,19 @@
 
 namespace Auryn;
 
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Context;
+
 class StandardReflector implements Reflector
 {
     public function getClass($class)
     {
-        return new \ReflectionClass($class);
+        return new ExtendedReflectionClass($class);
     }
 
     public function getCtor($class)
     {
-        $reflectionClass = new \ReflectionClass($class);
+        $reflectionClass = new ExtendedReflectionClass($class);
 
         return $reflectionClass->getConstructor();
     }
@@ -42,5 +45,23 @@ class StandardReflector implements Reflector
             : get_class($classNameOrInstance);
 
         return new \ReflectionMethod($className, $methodName);
+    }
+
+    public function getDocBlock($method)
+    {
+        $class = $this->getClass($method->class);
+
+        return new DocBlock(
+            $method->getDocComment(),
+            new Context(
+                $class->getNamespaceName(),
+                $class->getUseStatements()
+            )
+        );
+    }
+
+    public function getImplemented($className)
+    {
+        return array_merge(array($className), class_implements($className));
     }
 }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -103,6 +103,26 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Second argument', $injected->arg2);
     }
 
+    public function testMakeInstanceBasedOnTypeHintingWithCustomDefinitionOrder()
+    {
+        $injector = new Injector;
+        $injected = $injector->make('Auryn\Test\TestMultiDepsNeeded', [new TestDependency2()]);
+
+        $this->assertEquals(get_class($injected->testDep), 'Auryn\Test\TestDependency');
+        $this->assertEquals(get_class($injected->testDep2), 'Auryn\Test\TestDependency2');
+        $this->assertTrue(in_array('Auryn\Test\DepInterface', class_implements($injected->testDep2)));
+    }
+
+    public function testMakeInstanceBasedOnDocBlocksWithCustomDefinitionOrder()
+    {
+        $injector = new Injector;
+        $injected = $injector->make('Auryn\Test\TestMultiDepsNeeded2', [new TestDependency2()]);
+
+        $this->assertEquals(get_class($injected->testDep), 'Auryn\Test\TestDependency');
+        $this->assertEquals(get_class($injected->testDep2), 'Auryn\Test\TestDependency2');
+        $this->assertTrue(in_array('Auryn\Test\DepInterface', class_implements($injected->testDep2)));
+    }
+
     public function testMakeInstanceStoresShareIfMarkedWithNullInstance()
     {
         $injector = new Injector;

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -8,6 +8,7 @@ class InaccessibleExecutableClassMethod
     {
         return 42;
     }
+
     protected function doSomethingProtected()
     {
         return 42;
@@ -20,6 +21,7 @@ class InaccessibleStaticExecutableClassMethod
     {
         return 42;
     }
+
     protected static function doSomethingProtected()
     {
         return 42;
@@ -99,6 +101,7 @@ class NotSharedClass implements SharedAliasedInterface
 class DependencyWithDefinedParam
 {
     public $foo;
+
     public function __construct($foo)
     {
         $this->foo = $foo;
@@ -108,6 +111,7 @@ class DependencyWithDefinedParam
 class RequiresDependencyWithDefinedParam
 {
     public $obj;
+
     public function __construct(DependencyWithDefinedParam $obj)
     {
         $this->obj = $obj;
@@ -146,7 +150,7 @@ class TestDependency
     public $testProp = 'testVal';
 }
 
-class TestDependency2 extends TestDependency
+class TestDependency2 extends TestDependency implements DepInterface
 {
     public $testProp = 'testVal2';
 }
@@ -174,13 +178,37 @@ class TestClassWithNoCtorTypehints
 
 class TestMultiDepsNeeded
 {
-    public function __construct(TestDependency $val1, TestDependency2 $val2)
+    public function __construct(TestDependency $val1, DepInterface $val2)
     {
-        $this->testDep = $val1;
-        $this->testDep = $val2;
+        $this->testDep  = $val1;
+        $this->testDep2 = $val2;
     }
 }
 
+class TestMultiDepsNeeded2
+{
+    /**
+     * TestMultiDepsNeeded2 constructor.
+     *
+     * @param TestDependency $val1
+     * @param DepInterface   $val2
+     *
+     * @throws \Exception
+     */
+    public function __construct($val1, $val2)
+    {
+        if (!($val1 instanceof TestDependency)) {
+            throw new \Exception('param $val1 does not meet required input');
+        }
+
+        if (!($val2 instanceof TestDependency2)) {
+            throw new \Exception('param $val2 does not meet required input');
+        }
+
+        $this->testDep  = $val1;
+        $this->testDep2 = $val2;
+    }
+}
 
 class TestMultiDepsWithCtor
 {
@@ -194,7 +222,8 @@ class TestMultiDepsWithCtor
 class NoTypehintNullDefaultConstructorClass
 {
     public $testParam = 1;
-    public function __construct(TestDependency $val1, $arg=42)
+
+    public function __construct(TestDependency $val1, $arg = 42)
     {
         $this->testParam = $arg;
     }
@@ -203,6 +232,7 @@ class NoTypehintNullDefaultConstructorClass
 class NoTypehintNoDefaultConstructorClass
 {
     public $testParam = 1;
+
     public function __construct(TestDependency $val1, $arg = null)
     {
         $this->testParam = $arg;
@@ -212,12 +242,15 @@ class NoTypehintNoDefaultConstructorClass
 interface DepInterface
 {
 }
+
 interface SomeInterface
 {
 }
+
 class SomeImplementation implements SomeInterface
 {
 }
+
 class PreparesImplementationTest implements SomeInterface
 {
     public $testProp = 0;
@@ -231,6 +264,7 @@ class DepImplementation implements DepInterface
 class RequiresInterface
 {
     public $dep;
+
     public function __construct(DepInterface $dep)
     {
         $this->testDep = $dep;
@@ -240,20 +274,24 @@ class RequiresInterface
 class ClassInnerA
 {
     public $dep;
+
     public function __construct(ClassInnerB $dep)
     {
         $this->dep = $dep;
     }
 }
+
 class ClassInnerB
 {
     public function __construct()
     {
     }
 }
+
 class ClassOuter
 {
     public $dep;
+
     public function __construct(ClassInnerA $dep)
     {
         $this->dep = $dep;
@@ -275,6 +313,7 @@ interface TestNoExplicitDefine
 class InjectorTestCtorParamWithNoTypehintOrDefault implements TestNoExplicitDefine
 {
     public $val = 42;
+
     public function __construct($val)
     {
         $this->val = $val;
@@ -284,6 +323,7 @@ class InjectorTestCtorParamWithNoTypehintOrDefault implements TestNoExplicitDefi
 class InjectorTestCtorParamWithNoTypehintOrDefaultDependent
 {
     private $param;
+
     public function __construct(TestNoExplicitDefine $param)
     {
         $this->param = $param;
@@ -303,12 +343,12 @@ class InjectorTestRawCtorParams
     public function __construct($string, $obj, $int, $array, $float, $bool, $null)
     {
         $this->string = $string;
-        $this->obj = $obj;
-        $this->int = $int;
-        $this->array = $array;
-        $this->float = $float;
-        $this->bool = $bool;
-        $this->null = $null;
+        $this->obj    = $obj;
+        $this->int    = $int;
+        $this->array  = $array;
+        $this->float  = $float;
+        $this->bool   = $bool;
+        $this->null   = $null;
     }
 }
 
@@ -339,6 +379,7 @@ class CallableMock
 class ProviderTestCtorParamWithNoTypehintOrDefault implements TestNoExplicitDefine
 {
     public $val = 42;
+
     public function __construct($val)
     {
         $this->val = $val;
@@ -348,6 +389,7 @@ class ProviderTestCtorParamWithNoTypehintOrDefault implements TestNoExplicitDefi
 class ProviderTestCtorParamWithNoTypehintOrDefaultDependent
 {
     private $param;
+
     public function __construct(TestNoExplicitDefine $param)
     {
         $this->param = $param;
@@ -360,10 +402,12 @@ class StringStdClassDelegateMock
     {
         return $this->make();
     }
+
     private function make()
     {
-        $obj = new \StdClass;
+        $obj       = new \StdClass;
         $obj->test = 42;
+
         return $obj;
     }
 }
@@ -385,6 +429,7 @@ class ExecuteClassDeps
     public function __construct(TestDependency $testDep)
     {
     }
+
     public function execute()
     {
         return 42;
@@ -396,6 +441,7 @@ class ExecuteClassDepsWithMethodDeps
     public function __construct(TestDependency $testDep)
     {
     }
+
     public function execute(TestDependency $dep, $arg = null)
     {
         return isset($arg) ? $arg : 42;
@@ -476,6 +522,7 @@ class RequiresDelegatedInterface
     {
         $this->interface = $interface;
     }
+
     public function foo()
     {
         $this->interface->foo();
@@ -492,6 +539,7 @@ class TestMissingDependency
 class NonConcreteDependencyWithDefaultValue
 {
     public $interface;
+
     public function __construct(DelegatableInterface $i = null)
     {
         $this->interface = $i;
@@ -502,6 +550,7 @@ class NonConcreteDependencyWithDefaultValue
 class ConcreteDependencyWithDefaultValue
 {
     public $dependency;
+
     public function __construct(\StdClass $instance = null)
     {
         $this->dependency = $instance;
@@ -596,6 +645,7 @@ class TestDelegationSimple
 class TestDelegationDependency
 {
     public $delgateCalled = false;
+
     public function __construct(TestDelegationSimple $testDelegationSimple)
     {
     }
@@ -603,7 +653,7 @@ class TestDelegationDependency
 
 function createTestDelegationSimple()
 {
-    $instance = new TestDelegationSimple;
+    $instance                 = new TestDelegationSimple;
     $instance->delegateCalled = true;
 
     return $instance;
@@ -611,7 +661,7 @@ function createTestDelegationSimple()
 
 function createTestDelegationDependency(TestDelegationSimple $testDelegationSimple)
 {
-    $instance = new TestDelegationDependency($testDelegationSimple);
+    $instance                 = new TestDelegationDependency($testDelegationSimple);
     $instance->delegateCalled = true;
 
     return $instance;
@@ -624,6 +674,7 @@ class BaseExecutableClass
     {
         return 'This is the BaseExecutableClass';
     }
+
     public static function bar()
     {
         return 'This is the BaseExecutableClass';
@@ -636,6 +687,7 @@ class ExtendsExecutableClass extends BaseExecutableClass
     {
         return 'This is the ExtendsExecutableClass';
     }
+
     public static function bar()
     {
         return 'This is the ExtendsExecutableClass';
@@ -675,6 +727,7 @@ function getDelegateClosureInGlobalScope()
 class CloneTest
 {
     public $injector;
+
     public function __construct(\Auryn\Injector $injector)
     {
         $this->injector = clone $injector;
@@ -704,12 +757,16 @@ class DependencyChainTest
     }
 }
 
-class ParentWithConstructor {
+class ParentWithConstructor
+{
     public $foo;
-    function __construct($foo) {
+
+    function __construct($foo)
+    {
         $this->foo = $foo;
     }
 }
 
-class ChildWithoutConstructor extends ParentWithConstructor {
+class ChildWithoutConstructor extends ParentWithConstructor
+{
 }


### PR DESCRIPTION
Code example;

```php
<?php

namespace Auryn\Test;

use Auryn\Injector;

interface DepInterface
{
}


class TestDependency
{
    public $testProp = 'testVal';
}


class TestDependency2 extends TestDependency implements DepInterface
{
    public $testProp = 'testVal2';
}


class TestMultiDepsNeeded
{
    public function __construct(TestDependency $val1, DepInterface $val2)
    {
        $this->testDep  = $val1;
        $this->testDep2 = $val2;
    }
}


class TestMultiDepsNeededExample2
{
    /**
     * TestMultiDepsNeededExample2 constructor.
     *
     * @param TestDependency $val1
     * @param DepInterface   $val2
     *
     * @throws \Exception
     */
    public function __construct($val1, $val2)
    {
        if (!($val1 instanceof TestDependency)) {
            throw new \Exception('param $val1 does not meet required input');
        }

        if (!($val2 instanceof TestDependency2)) {
            throw new \Exception('param $val2 does not meet required input');
        }

        $this->testDep  = $val1;
        $this->testDep2 = $val2;
    }
}
```

Previously not possible;

```php
// try instantiate class 'TestMultiDepsNeeded'
$injector = new Injector;
$injected = $injector->make('Auryn\Test\TestMultiDepsNeeded', [new TestDependency2()]);

// fails ...
```
The code above will not instantiate class ```'Auryn\Test\TestMultiDepsNeeded'``` because Auryn will try to match the Entity passed in the second parameter of ```$injector->make()``` to ```TestMultiDepsNeeded::__construct(TestDependency $val1, [..]);```

```php
// try instantiate class 'TestMultiDepsNeeded'
$injector = new Injector;
$injected = $injector->make('Auryn\Test\TestMultiDepsNeeded', [new TestDependency2()]);

// works now!
```

With the fix provided in this PR the same code mentioned above will execute nicely. Auryn will now look for a particular parameter in the ```__construct()``` method which meets the Enity' class name (or one of it's implemented interfaces) and assign it to the correct parameter in the ```__construct()``` method.

This is particularly handy when your are dynamically instantiating classes with a different amount of parameters and where the parameters are constantly in a different order.

The following is also possible now;

*please note that no parameters of ```TestMultiDepsNeededExample2::__construct()``` are type hinted, do mind its doc block which does specify type hinting*

```php
// try instantiate class 'TestMultiDepsNeededExample2'
$injector = new Injector;
$injected = $injector->make('Auryn\Test\TestMultiDepsNeededExample2', [new TestDependency2()]);

// also works now!
```

- When both method parameters are type hinted and a method doc block is set, the type hinted method parameters take precedence.
- (fixed already broken tests) added tests to prove the above mentioned features





