### PR TITLE
Prevent caching of delegate closures

### DIFF
--- a/lib/CachingReflector.php
+++ b/lib/CachingReflector.php
@@ -75,7 +75,7 @@ class CachingReflector implements Reflector
             $paramCacheKey = self::CACHE_KEY_CLASSES . "{$lowClass}.{$lowMethod}.param-{$lowParam}";
         } else {
             $lowFunc = strtolower($function->name);
-            $paramCacheKey = ($lowFunc !== '{closure}')
+            $paramCacheKey = (strpos($lowFunc, '{closure}') === false)
                 ? self::CACHE_KEY_FUNCS . ".{$lowFunc}.param-{$lowParam}"
                 : null;
         }

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1112,4 +1112,21 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $injector->define('Auryn\Test\ParentWithConstructor', array(':foo' => 'parent'));
         $injector->make('Auryn\Test\ChildWithoutConstructor');
     }
+
+    public function testInstanceClosureDelegates()
+    {
+        $injector = new Injector;
+        $injector->delegate('Auryn\Test\DelegatingInstanceA', function (DelegateA $d) {
+            return new \Auryn\Test\DelegatingInstanceA($d);
+        });
+        $injector->delegate('Auryn\Test\DelegatingInstanceB', function (DelegateB $d) {
+            return new \Auryn\Test\DelegatingInstanceB($d);
+        });
+
+        $a = $injector->make('Auryn\Test\DelegatingInstanceA');
+        $b = $injector->make('Auryn\Test\DelegatingInstanceB');
+
+        $this->assertInstanceOf('Auryn\Test\DelegateA', $a->a);
+        $this->assertInstanceOf('Auryn\Test\DelegateB', $b->b);
+    }
 }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -713,3 +713,17 @@ class ParentWithConstructor {
 
 class ChildWithoutConstructor extends ParentWithConstructor {
 }
+
+class DelegateA {}
+class DelegatingInstanceA {
+    public function __construct(DelegateA $a) {
+        $this->a = $a;
+    }
+}
+
+class DelegateB {}
+class DelegatingInstanceB {
+    public function __construct(DelegateB $b) {
+        $this->b = $b;
+    }
+}


### PR DESCRIPTION
Two different closures using the same parameter name should not end up
with the same parameters.