### PR TITLE
Make inspect() return all references by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: trusty
+
 language: php
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -8,9 +10,15 @@ php:
   - 7.1
   - nightly
   - hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+
 before_script:
   - composer install
-sudo: false
+
 script:
   - phpunit
   - vendor/bin/athletic --path test/Benchmark --formatter GroupedFormatter

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -12,7 +12,7 @@ class Injector
     const I_PREPARES = 4;
     const I_ALIASES = 8;
     const I_SHARES = 16;
-    const I_ALL = 17;
+    const I_ALL = 31;
 
     const E_NON_EMPTY_STRING_ALIAS = 1;
     const M_NON_EMPTY_STRING_ALIAS = "Invalid alias: non-empty string required at arguments 1 and 2";

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1062,6 +1062,32 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('auryn\test\someclassname', $inspection[Injector::I_SHARES]);
     }
 
+    public function testInspectAll()
+    {
+        $injector = new Injector();
+
+        // Injector::I_BINDINGS
+        $injector->define('Auryn\Test\DependencyWithDefinedParam', array(':arg' => 42));
+
+        // Injector::I_DELEGATES
+        $injector->delegate('Auryn\Test\MadeByDelegate', 'Auryn\Test\CallableDelegateClassTest');
+
+        // Injector::I_PREPARES
+        $injector->prepare('Auryn\Test\MadeByDelegate', function ($c) {});
+
+        // Injector::I_ALIASES
+        $injector->alias('i', 'Auryn\Injector');
+
+        // Injector::I_SHARES
+        $injector->share('Auryn\Injector');
+
+        $all = $injector->inspect();
+        $some = $injector->inspect('Auryn\Test\MadeByDelegate');
+
+        $this->assertCount(5, array_filter($all));
+        $this->assertCount(2, array_filter($some));
+    }
+
     /**
      * @expectedException \Auryn\InjectionException
      * @expectedExceptionCode \Auryn\Injector::E_MAKING_FAILED


### PR DESCRIPTION
The correct bitmask for *all* identifiers is `31` not `17`.

Fixes #157