### PR TITLE
Add the ability to create named dependencies

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -701,7 +701,9 @@ class Injector
 
     private function buildExecutableStructFromString($stringExecutable)
     {
-        if (function_exists($stringExecutable)) {
+        if ($stringExecutable[0] == self::A_LABEL) {
+            $executableStruct = $this->buildExecutableStruct($this->make($stringExecutable));
+        } elseif (function_exists($stringExecutable)) {
             $callableRefl = $this->reflector->getFunction($stringExecutable);
             $executableStruct = array($callableRefl, null);
         } elseif (method_exists($stringExecutable, '__invoke')) {

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -148,9 +148,9 @@ class Injector
      * @param array $params Parameters to be passed into make
      * @return self
      */
-    public function defineLabel($label, $class, array $params)
+    public function defineLabel($label, $class, array $params = array())
     {
-        $this->labels[self::A_LABEL.$label] = array($class, $params);
+        $this->labels[$this->normalizeName(self::A_LABEL.$label)] = array($class, $params);
         return $this;
     }
 
@@ -354,8 +354,18 @@ class Injector
      */
     public function make($name, array $args = array())
     {
-        if ($name[0] === self::A_LABEL && array_key_exists($name, $this->labels)){
-            return $this->make($this->labels[$name][0], $this->labels[$name][1]);
+        $normalizedName = $this->normalizeName($name);
+        if ($normalizedName[0] === self::A_LABEL && array_key_exists($normalizedName, $this->labels)){
+
+            if (isset($this->shares[$normalizedName])) {
+                return $this->shares[$normalizedName];
+            }
+            $obj = $this->make($this->labels[$normalizedName][0], $this->labels[$normalizedName][1]);
+
+            if (array_key_exists($normalizedName, $this->shares)) {
+                $this->shares[$normalizedName] = $obj;
+            }
+            return $obj;
         }
         list($className, $normalizedClass) = $this->resolveAlias($name);
 

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -471,7 +471,9 @@ class Injector
                 // interpret the param as a class name to be instantiated
                 $arg = $this->make($definition[$name]);
             } elseif (($prefix = self::A_RAW . $name) && (isset($definition[$prefix]) || array_key_exists($prefix, $definition))) {
+                // interpret the param as a raw value to be injected
                 $arg = $definition[$prefix];
+
                 if (is_string($arg) && $arg[0] === self::A_LABEL && isset($this->labels[$arg])) {
                     $arg = $this->make(
                         $this->labels[$arg][0], 
@@ -496,6 +498,7 @@ class Injector
 
             $args[] = $arg;
         }
+        
         return $args;
     }
 

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -150,7 +150,7 @@ class Injector
      */
     public function defineLabel($label, $class, array $params)
     {
-        $this->labels[self::A_LABEL.$label] = [$class, $params];
+        $this->labels[self::A_LABEL.$label] = array($class, $params);
         return $this;
     }
 

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -498,7 +498,7 @@ class Injector
 
             $args[] = $arg;
         }
-        
+
         return $args;
     }
 

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -606,6 +606,17 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         return $return;
     }
 
+    public function testExecuteLabeledDefinition()
+    {
+        $injector = new Injector;
+        $injector->defineLabel('some.dependency', 'Auryn\Test\RequiresDependencyWithTypelessParameters', array(
+            ':dependency' => new TypelessParameterDependency(150)
+        ));
+        $injector->defineLabel('test.executable', 'Auryn\Test\ExecuteClassInvokableWithInjectedProperty', array(':dependency' => '#some.dependency'));
+        $result = $injector->execute('#test.executable');
+        $this->assertSame(150, $result->dependency->thumbnailSize);
+    }
+
     public function testStaticStringInvokableWithArgument()
     {
         $injector = new \Auryn\Injector;

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -235,6 +235,34 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($obj->null);
     }
 
+    public function testMakeLabeledInstanceDirectly()
+    {
+        $injector = new Injector;
+
+        $injector->defineLabel('desktop', 'Auryn\Test\TypelessParameterDependency', array(
+            ':thumbnailSize' => 300
+        ));
+
+
+        $obj = $injector->make('#desktop');
+        $this->assertEquals($obj->thumbnailSize, 300);
+    }
+
+    public function testMakeInstanceWithLabeledParametersRecursively()
+    {
+        $injector = new Injector;
+        $injector->defineLabel('parent', 'Auryn\Test\RequiresDependencyWithTypelessParameters', array(
+            ':dependency' => '#injected'
+        ));
+        $injector->defineLabel('injected', 'Auryn\Test\TypelessParameterDependency', array(
+            ':thumbnailSize' => 300
+        ));
+
+        $obj = $injector->make('#parent');
+
+        $this->assertSame($obj->dependency->thumbnailSize, 300);
+    }
+
     /**
      * @TODO
      * @expectedException \Exception

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -659,6 +659,15 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($class, $class2);
     }
 
+    public function testShareByLabel()
+    {
+        $injector = new Injector;
+        $injector->defineLabel('sharedDependency', 'Auryn\Test\SharedClass');
+        $injector->share('#sharedDependency');
+        $obj1 = $injector->make('#sharedDependency');
+        $obj2 = $injector->make('#sharedDependency');
+        $this->assertSame($obj1, $obj2);
+    }
     public function testNotSharedByAliasedInterfaceName()
     {
         $injector = new Injector;

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -417,7 +417,19 @@ class ExecuteClassRelativeStaticMethod extends ExecuteClassStaticMethod
         return 'this should NEVER be seen since we are testing against parent::execute()';
     }
 }
+class ExecuteClassInvokableWithInjectedProperty
+{
+    public $dependency;
 
+    public function __construct($dependency){
+        $this->dependency = $dependency;
+    }
+
+    public function __invoke()
+    {
+        return $this->dependency;
+    }
+}
 class ExecuteClassInvokable
 {
     public function __invoke()


### PR DESCRIPTION
Allows the creation of a named dependency using

`$injector->defineLabel('dependency_label', '/Fully/Qualified/Classname', ['arg1'=>'val1']);`

later to be dereferenced during make by:

`$injector->make('#dependency_label');`
