### PR TITLE
export ignore test,examples in distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/examples          export-ignore
+/test              export-ignore


### PR DESCRIPTION
would be great if we wouldn't get tests and examples via composer when installing with --prefer-dist.

for background see https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/