### PR TITLE
fix rdlowrey/auryn#129

### DIFF
--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -464,7 +464,7 @@ class Injector
             } elseif (!$arg = $this->buildArgFromTypeHint($reflFunc, $reflParam)) {
                 $arg = $this->buildArgFromReflParam($reflParam);
 
-                if ($arg === null && PHP_VERSION_ID >= 50600 && $reflParam->isVariadic()) {
+                if ($arg === null && (PHP_VERSION_ID >= 50600 && $reflParam->isVariadic() || $reflParam->isOptional())) {
                     // buildArgFromReflParam might return null in case the parameter is optional
                     // in case of variadics, the parameter is optional, but null might not be allowed
                     continue;

--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1194,4 +1194,12 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Auryn\Test\DelegateA', $a->a);
         $this->assertInstanceOf('Auryn\Test\DelegateB', $b->b);
     }
+
+    public function testProvidesExtensionsOfArrayMap()
+    {
+        $injector = New Injector;
+        $obj = $injector->make('\Auryn\Test\ExtendedExtendedArrayObject');
+
+        $this->assertInstanceOf('\ArrayObject', $obj);
+    }
 }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -727,3 +727,6 @@ class DelegatingInstanceB {
         $this->b = $b;
     }
 }
+
+class ExtendedArrayObject extends \ArrayObject {}
+class ExtendedExtendedArrayObject extends ExtendedArrayObject {}


### PR DESCRIPTION
This should fix #129 

I've found this issue while looking for a solution to the same problem I had in my own DI library. It seems that PHP incorrectly states that the argument accepts `null`. The solution I propose (I've done so in my own library) is not to collect `null` as an argument from reflection when no value is given by the user and reflection tells the argument is optional, rather than accepting `null` when reflection tells it also allows null while being optional.