### PR TITLE
Use locally installed phpunit in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ before_script:
   - composer install
 
 script:
-  - phpunit
+  - vendor/bin/phpunit
   - vendor/bin/athletic --path test/Benchmark --formatter GroupedFormatter


### PR DESCRIPTION
I didn't like the red status badge on this library.

I think the build should use the locally installed PHPUnit version from vendor dir, it matches the current PHP version.