### PR TITLE
Unset provisioning in progress when provisioning throws exception

### DIFF
--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -1194,4 +1194,21 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Auryn\Test\DelegateA', $a->a);
         $this->assertInstanceOf('Auryn\Test\DelegateB', $b->b);
     }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Exception in constructor
+     */
+    public function testThatExceptionInConstructorDoesntCauseCyclicDependencyException()
+    {
+        $injector = new Injector;
+
+        try {
+            $injector->make('Auryn\Test\ThrowsExceptionInConstructor');
+        }
+        catch (\Exception $e) {
+        }
+
+        $injector->make('Auryn\Test\ThrowsExceptionInConstructor');
+    }
 }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -727,3 +727,9 @@ class DelegatingInstanceB {
         $this->b = $b;
     }
 }
+
+class ThrowsExceptionInConstructor {
+    public function __construct() {
+        throw new \Exception('Exception in constructor');
+    }
+}


### PR DESCRIPTION
If an exception will be thrown when provisioning the class instance, the
injector won't clear the inProgressMake flag for this class, causing
cyclic dependency exception when the instance for this class will be
requested again.