### PR TITLE
Add test failing on array types on PHP 8+

### DIFF
--- a/test/InjectorTest.php
+++ b/test/InjectorTest.php
@@ -7,6 +7,13 @@ use PHPUnit\Framework\TestCase;
 
 class InjectorTest extends TestCase
 {
+    public function testArrayTypehintDoesNotEvaluatesAsClass()
+    {
+        $injector = new Injector;
+        $injector->defineParam('parameter', []);
+        $injector->execute('Auryn\Test\hasArrayDependency');
+    }
+
     public function testMakeInstanceInjectsSimpleConcreteDependency()
     {
         $injector = new Injector;

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -426,6 +426,11 @@ class ExecuteClassInvokable
     }
 }
 
+function hasArrayDependency(array $parameter)
+{
+    return 42;
+}
+
 function testExecuteFunction()
 {
     return 42;


### PR DESCRIPTION
After [a discussion](https://chat.stackoverflow.com/transcript/message/51709392#51709392) in r11 it appears that from [this PR](https://github.com/rdlowrey/auryn/pull/189) the behaviour changed so that in PHP80+ typehinting an array fails because getType returns the actual string `"array"` whereas pre-PHP80 the value was simply null.

Returning `"array"` causes auryn to try and instantiate an array, which is not a class, and triggers `error 8: Could not make array: Class "array" does not exist`.

Orthogonally, phpunit being at version 4 makes it incompatible with PHP80+, which is necessary to make the test fail.  Allegedly this would be fixed by https://github.com/rdlowrey/auryn/pull/188.

cmb in chat proposed a [quick stub](https://3v4l.org/R3dn1) that could solve the issue. The changes do not seem to impact in any way the code from the phpunit upgrade PR so there's no merging order requirement.