### PR TITLE
Add note about maintenance status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 auryn is a recursive dependency injector. Use auryn to bootstrap and wire together
 S.O.L.I.D., object-oriented PHP applications.
 
+## Maintenance status
+
+`rdlowrey/auryn` is no longer maintained. For a repo that is still under maintenance you have two 
+options:
+
+* Switch to [`amphp/injector`](https://github.com/amphp/injector). It is a significant rewrite and
+  uses a new namespace and slightly different interfaces, requiring you to update your code. It
+  will introduce new features and diverge over time from this repo.
+* Use [`martin-hughes/auryn`](https://github.com/martin-hughes/auryn). It is a fork from this repo
+  and maintains the current namespace and interfaces. It is unlikely to introduce significant new 
+  features, instead focussing on bugfixes and testing.
+
 ##### How It Works
 
 Among other things, auryn recursively instantiates class dependencies based on the parameter

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "rdlowrey/auryn",
+    "abandoned": true,
     "homepage": "https://github.com/rdlowrey/auryn",
     "description": "Auryn is a dependency injector for bootstrapping object-oriented PHP applications.",
     "keywords": ["dependency injection", "dic", "ioc"],


### PR DESCRIPTION
I've decided to publish a fork of auryn and to maintain that myself, rather than the new AMPHP version. Since this repo is effectively unmaintained, I thought I'd offer my fork as a replacement whilst noting the AMPHP version as well. As such, I thought I'd offer a few notes to put in the readme of this repo explaining the situation.

I know that new projects should probably use AMPHP, but I was recently working on a large commercial project where that would be a reasonably large amount of work - and technical risk - and there was an appetite to keep using 'original' auryn with bugfixes.

Take it or leave it, of course :)