### PR TITLE
Fix normalization of ? optional typehints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
-    "name": "rdlowrey/auryn",
-    "homepage": "https://github.com/rdlowrey/auryn",
+    "name": "dotink/auryn",
     "description": "Auryn is a dependency injector for bootstrapping object-oriented PHP applications.",
     "keywords": ["dependency injection", "dic", "ioc"],
     "license": "MIT",

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -141,7 +141,7 @@ class Injector
 
     private function normalizeName($className)
     {
-        return ltrim(strtolower($className), '\\');
+        return ltrim(strtolower($className), '\\?');
     }
 
     /**


### PR DESCRIPTION
If you define an alias for a typehint and then create an optional parameter on a constructor, e.g. My\Interface $param = NULL the $typeHint returned implicitly has '?' at the front.  This is a simple hint to remove the '?' so that proper resolution of any registered aliases/delegates/etc, can be run.