### PR TITLE
Fix PHP 8.4 deprecation

### DIFF
--- a/lib/CachingReflector.php
+++ b/lib/CachingReflector.php
@@ -13,7 +13,7 @@ class CachingReflector implements Reflector
     private $reflector;
     private $cache;
 
-    public function __construct(Reflector $reflector = null, ReflectionCache $cache = null)
+    public function __construct(?Reflector $reflector = null, ?ReflectionCache $cache = null)
     {
         $this->reflector = $reflector ?: new StandardReflector;
         $this->cache = $cache ?: new ReflectionCacheArray;

--- a/lib/InjectionException.php
+++ b/lib/InjectionException.php
@@ -6,7 +6,7 @@ class InjectionException extends InjectorException
 {
     public $dependencyChain;
     
-    public function __construct(array $inProgressMakes, $message = "", $code = 0, \Exception $previous = null)
+    public function __construct(array $inProgressMakes, $message = "", $code = 0, ?\Exception $previous = null)
     {
         $this->dependencyChain = array_flip($inProgressMakes);
         ksort($this->dependencyChain);
@@ -20,7 +20,7 @@ class InjectionException extends InjectorException
     public static function fromInvalidCallable(
         array $inProgressMakes,
         $callableOrMethodStr,
-        \Exception $previous = null
+        ?\Exception $previous = null
     ) {
         $callableString = null;
 

--- a/lib/Injector.php
+++ b/lib/Injector.php
@@ -48,7 +48,7 @@ class Injector
     private $delegates = array();
     private $inProgressMakes = array();
 
-    public function __construct(Reflector $reflector = null)
+    public function __construct(?Reflector $reflector = null)
     {
         $this->reflector = $reflector ?: new CachingReflector;
     }
@@ -444,7 +444,7 @@ class Injector
         return new $className;
     }
 
-    private function provisionFuncArgs(\ReflectionFunctionAbstract $reflFunc, array $definition, array $reflParams = null, $className = null)
+    private function provisionFuncArgs(\ReflectionFunctionAbstract $reflFunc, array $definition, ?array $reflParams = null, $className = null)
     {
         $args = array();
 

--- a/lib/ReflectionCacheApc.php
+++ b/lib/ReflectionCacheApc.php
@@ -7,7 +7,7 @@ class ReflectionCacheApc implements ReflectionCache
     private $localCache;
     private $timeToLive = 5;
 
-    public function __construct(ReflectionCache $localCache = null)
+    public function __construct(?ReflectionCache $localCache = null)
     {
         $this->localCache = $localCache ?: new ReflectionCacheArray;
     }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -497,7 +497,7 @@ class TestMissingDependency
 class NonConcreteDependencyWithDefaultValue
 {
     public $interface;
-    public function __construct(DelegatableInterface $i = null)
+    public function __construct(?DelegatableInterface $i = null)
     {
         $this->interface = $i;
     }
@@ -507,7 +507,7 @@ class NonConcreteDependencyWithDefaultValue
 class ConcreteDependencyWithDefaultValue
 {
     public $dependency;
-    public function __construct(\StdClass $instance = null)
+    public function __construct(?\StdClass $instance = null)
     {
         $this->dependency = $instance;
     }


### PR DESCRIPTION
Adds explicit `?` nullable typehint to satisfy 8.4 deprecation notices